### PR TITLE
Implement additional production domain modules

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,10 @@ import { MinutaModule } from './minuta/minuta.module';
 import { RegistroMinutoModule } from './registro-minuto/registro-minuto.module';
 import { ProductividadModule } from './productividad/productividad.module';
 import { AuthModule } from './auth/auth.module';
+import { SesionTrabajoModule } from './sesion-trabajo/sesion-trabajo.module';
+import { EstadoRecursoModule } from './estado-recurso/estado-recurso.module';
+import { EmpresaModule } from './empresa/empresa.module';
+import { MaterialOrdenModule } from './material-orden/material-orden.module';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -55,6 +59,14 @@ import * as path from 'path';
   MinutaModule,
 
   RegistroMinutoModule,
+
+  SesionTrabajoModule,
+
+  EstadoRecursoModule,
+
+  EmpresaModule,
+
+  MaterialOrdenModule,
 
   ProductividadModule,
 

--- a/src/empresa/dto/create-empresa.dto.ts
+++ b/src/empresa/dto/create-empresa.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateEmpresaDto {
+  @IsString()
+  nombre: string;
+}

--- a/src/empresa/dto/update-empresa.dto.ts
+++ b/src/empresa/dto/update-empresa.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class UpdateEmpresaDto {
+  @IsOptional()
+  @IsString()
+  nombre?: string;
+}

--- a/src/empresa/empresa.controller.ts
+++ b/src/empresa/empresa.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Put, Delete, Body, Param } from '@nestjs/common';
+import { EmpresaService } from './empresa.service';
+import { CreateEmpresaDto } from './dto/create-empresa.dto';
+import { UpdateEmpresaDto } from './dto/update-empresa.dto';
+
+@Controller('empresas')
+export class EmpresaController {
+  constructor(private readonly service: EmpresaService) {}
+
+  @Post()
+  create(@Body() dto: CreateEmpresaDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateEmpresaDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/empresa/empresa.entity.ts
+++ b/src/empresa/empresa.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('empresa')
+export class Empresa {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  nombre: string;
+}

--- a/src/empresa/empresa.module.ts
+++ b/src/empresa/empresa.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Empresa } from './empresa.entity';
+import { EmpresaService } from './empresa.service';
+import { EmpresaController } from './empresa.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Empresa])],
+  providers: [EmpresaService],
+  controllers: [EmpresaController],
+})
+export class EmpresaModule {}

--- a/src/empresa/empresa.service.ts
+++ b/src/empresa/empresa.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Empresa } from './empresa.entity';
+import { CreateEmpresaDto } from './dto/create-empresa.dto';
+import { UpdateEmpresaDto } from './dto/update-empresa.dto';
+
+@Injectable()
+export class EmpresaService {
+  constructor(@InjectRepository(Empresa) private readonly repo: Repository<Empresa>) {}
+
+  create(dto: CreateEmpresaDto) {
+    const empresa = this.repo.create(dto);
+    return this.repo.save(empresa);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  async findOne(id: string) {
+    const empresa = await this.repo.findOne({ where: { id } });
+    if (!empresa) throw new NotFoundException('Empresa no encontrada');
+    return empresa;
+  }
+
+  async update(id: string, dto: UpdateEmpresaDto) {
+    const empresa = await this.repo.preload({ id, ...dto });
+    if (!empresa) throw new NotFoundException('Empresa no encontrada');
+    return this.repo.save(empresa);
+  }
+
+  async remove(id: string) {
+    const empresa = await this.repo.findOne({ where: { id } });
+    if (!empresa) throw new NotFoundException('Empresa no encontrada');
+    await this.repo.remove(empresa);
+    return { deleted: true };
+  }
+}

--- a/src/estado-recurso/dto/create-estado-recurso.dto.ts
+++ b/src/estado-recurso/dto/create-estado-recurso.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsUUID, IsDate, IsOptional } from 'class-validator';
+import { TipoEstadoRecurso } from '../estado-recurso.entity';
+
+export class CreateEstadoRecursoDto {
+  @IsUUID()
+  recurso: string;
+
+  @IsEnum(TipoEstadoRecurso)
+  estado: TipoEstadoRecurso;
+
+  @IsDate()
+  inicio: Date;
+
+  @IsOptional()
+  @IsDate()
+  fin?: Date;
+}

--- a/src/estado-recurso/dto/update-estado-recurso.dto.ts
+++ b/src/estado-recurso/dto/update-estado-recurso.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsUUID, IsDate, IsOptional } from 'class-validator';
+import { TipoEstadoRecurso } from '../estado-recurso.entity';
+
+export class UpdateEstadoRecursoDto {
+  @IsOptional()
+  @IsUUID()
+  recurso?: string;
+
+  @IsOptional()
+  @IsEnum(TipoEstadoRecurso)
+  estado?: TipoEstadoRecurso;
+
+  @IsOptional()
+  @IsDate()
+  inicio?: Date;
+
+  @IsOptional()
+  @IsDate()
+  fin?: Date;
+}

--- a/src/estado-recurso/estado-recurso.controller.ts
+++ b/src/estado-recurso/estado-recurso.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Param, Body, Put, Delete } from '@nestjs/common';
+import { EstadoRecursoService } from './estado-recurso.service';
+import { CreateEstadoRecursoDto } from './dto/create-estado-recurso.dto';
+import { UpdateEstadoRecursoDto } from './dto/update-estado-recurso.dto';
+
+@Controller('estados-recurso')
+export class EstadoRecursoController {
+  constructor(private readonly service: EstadoRecursoService) {}
+
+  @Post()
+  create(@Body() dto: CreateEstadoRecursoDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateEstadoRecursoDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/estado-recurso/estado-recurso.entity.ts
+++ b/src/estado-recurso/estado-recurso.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEntity } from 'typeorm';
+import { Recurso } from '../recurso/recurso.entity';
+
+export enum TipoEstadoRecurso {
+  DESCANSO = 'descanso',
+  MANTENIMIENTO = 'mantenimiento',
+  PRODUCCION = 'produccion',
+}
+
+@Entity('estado_recurso')
+export class EstadoRecurso extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Recurso, { nullable: false })
+  @JoinColumn({ name: 'recursoId' })
+  recurso: Recurso;
+
+  @Column({ type: 'enum', enum: TipoEstadoRecurso })
+  estado: TipoEstadoRecurso;
+
+  @Column({ type: 'timestamp' })
+  inicio: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  fin: Date;
+}

--- a/src/estado-recurso/estado-recurso.module.ts
+++ b/src/estado-recurso/estado-recurso.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EstadoRecurso } from './estado-recurso.entity';
+import { EstadoRecursoService } from './estado-recurso.service';
+import { EstadoRecursoController } from './estado-recurso.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EstadoRecurso])],
+  providers: [EstadoRecursoService],
+  controllers: [EstadoRecursoController],
+})
+export class EstadoRecursoModule {}

--- a/src/estado-recurso/estado-recurso.service.ts
+++ b/src/estado-recurso/estado-recurso.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EstadoRecurso } from './estado-recurso.entity';
+import { CreateEstadoRecursoDto } from './dto/create-estado-recurso.dto';
+import { UpdateEstadoRecursoDto } from './dto/update-estado-recurso.dto';
+
+@Injectable()
+export class EstadoRecursoService {
+  constructor(
+    @InjectRepository(EstadoRecurso)
+    private readonly repo: Repository<EstadoRecurso>,
+  ) {}
+
+  create(dto: CreateEstadoRecursoDto) {
+    const nuevo = this.repo.create({
+      ...dto,
+      recurso: { id: dto.recurso } as any,
+    });
+    return this.repo.save(nuevo);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['recurso'] });
+  }
+
+  async findOne(id: string) {
+    const estado = await this.repo.findOne({ where: { id }, relations: ['recurso'] });
+    if (!estado) throw new NotFoundException('Estado recurso no encontrado');
+    return estado;
+  }
+
+  async update(id: string, dto: UpdateEstadoRecursoDto) {
+    const estado = await this.repo.findOne({ where: { id } });
+    if (!estado) throw new NotFoundException('Estado recurso no encontrado');
+    if (dto.recurso) estado.recurso = { id: dto.recurso } as any;
+    Object.assign(estado, dto);
+    return this.repo.save(estado);
+  }
+
+  async remove(id: string) {
+    const estado = await this.repo.findOne({ where: { id } });
+    if (!estado) throw new NotFoundException('Estado recurso no encontrado');
+    await this.repo.remove(estado);
+    return { deleted: true };
+  }
+}

--- a/src/material-orden/dto/create-material-orden.dto.ts
+++ b/src/material-orden/dto/create-material-orden.dto.ts
@@ -1,0 +1,18 @@
+import { IsUUID, IsString, IsInt } from 'class-validator';
+
+export class CreateMaterialOrdenDto {
+  @IsUUID()
+  orden: string;
+
+  @IsString()
+  codigo: string;
+
+  @IsString()
+  descripcion: string;
+
+  @IsString()
+  unidad: string;
+
+  @IsInt()
+  cantidad: number;
+}

--- a/src/material-orden/dto/update-material-orden.dto.ts
+++ b/src/material-orden/dto/update-material-orden.dto.ts
@@ -1,0 +1,23 @@
+import { IsUUID, IsString, IsInt, IsOptional } from 'class-validator';
+
+export class UpdateMaterialOrdenDto {
+  @IsOptional()
+  @IsUUID()
+  orden?: string;
+
+  @IsOptional()
+  @IsString()
+  codigo?: string;
+
+  @IsOptional()
+  @IsString()
+  descripcion?: string;
+
+  @IsOptional()
+  @IsString()
+  unidad?: string;
+
+  @IsOptional()
+  @IsInt()
+  cantidad?: number;
+}

--- a/src/material-orden/material-orden.controller.ts
+++ b/src/material-orden/material-orden.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Put, Delete, Param, Body } from '@nestjs/common';
+import { MaterialOrdenService } from './material-orden.service';
+import { CreateMaterialOrdenDto } from './dto/create-material-orden.dto';
+import { UpdateMaterialOrdenDto } from './dto/update-material-orden.dto';
+
+@Controller('materiales-orden')
+export class MaterialOrdenController {
+  constructor(private readonly service: MaterialOrdenService) {}
+
+  @Post()
+  create(@Body() dto: CreateMaterialOrdenDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateMaterialOrdenDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/material-orden/material-orden.entity.ts
+++ b/src/material-orden/material-orden.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { OrdenProduccion } from '../orden-produccion/entity';
+
+@Entity('material_orden')
+export class MaterialOrden {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => OrdenProduccion, { nullable: false })
+  @JoinColumn({ name: 'ordenId' })
+  orden: OrdenProduccion;
+
+  @Column()
+  codigo: string;
+
+  @Column()
+  descripcion: string;
+
+  @Column()
+  unidad: string;
+
+  @Column('int')
+  cantidad: number;
+}

--- a/src/material-orden/material-orden.module.ts
+++ b/src/material-orden/material-orden.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MaterialOrden } from './material-orden.entity';
+import { MaterialOrdenService } from './material-orden.service';
+import { MaterialOrdenController } from './material-orden.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MaterialOrden])],
+  providers: [MaterialOrdenService],
+  controllers: [MaterialOrdenController],
+})
+export class MaterialOrdenModule {}

--- a/src/material-orden/material-orden.service.ts
+++ b/src/material-orden/material-orden.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MaterialOrden } from './material-orden.entity';
+import { CreateMaterialOrdenDto } from './dto/create-material-orden.dto';
+import { UpdateMaterialOrdenDto } from './dto/update-material-orden.dto';
+
+@Injectable()
+export class MaterialOrdenService {
+  constructor(
+    @InjectRepository(MaterialOrden) private readonly repo: Repository<MaterialOrden>,
+  ) {}
+
+  create(dto: CreateMaterialOrdenDto) {
+    const material = this.repo.create({
+      ...dto,
+      orden: { id: dto.orden } as any,
+    });
+    return this.repo.save(material);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['orden'] });
+  }
+
+  async findOne(id: string) {
+    const material = await this.repo.findOne({ where: { id }, relations: ['orden'] });
+    if (!material) throw new NotFoundException('Material no encontrado');
+    return material;
+  }
+
+  async update(id: string, dto: UpdateMaterialOrdenDto) {
+    const material = await this.repo.findOne({ where: { id } });
+    if (!material) throw new NotFoundException('Material no encontrado');
+    if (dto.orden) material.orden = { id: dto.orden } as any;
+    Object.assign(material, dto);
+    return this.repo.save(material);
+  }
+
+  async remove(id: string) {
+    const material = await this.repo.findOne({ where: { id } });
+    if (!material) throw new NotFoundException('Material no encontrado');
+    await this.repo.remove(material);
+    return { deleted: true };
+  }
+}

--- a/src/orden-produccion/dto/actualizar-progreso.dto.ts
+++ b/src/orden-produccion/dto/actualizar-progreso.dto.ts
@@ -1,8 +1,0 @@
-import { IsNumber, Min, Max } from 'class-validator'
-
-export class ActualizarProgresoDto {
-  @IsNumber()
-  @Min(0)
-  @Max(100)
-  progreso: number
-}

--- a/src/orden-produccion/dto/crear-orden.dto.ts
+++ b/src/orden-produccion/dto/crear-orden.dto.ts
@@ -1,10 +1,21 @@
-import { IsString, IsArray, IsOptional } from 'class-validator'
+import { IsString, IsInt, IsDate } from 'class-validator'
 
 export class CrearOrdenDto {
   @IsString()
-  codigo: string
+  numero: string
 
-  @IsArray()
-  @IsOptional()
-  pasos?: string[]
+  @IsString()
+  producto: string
+
+  @IsInt()
+  cantidadAProducir: number
+
+  @IsDate()
+  fechaOrden: Date
+
+  @IsDate()
+  fechaVencimiento: Date
+
+  @IsString()
+  estado: string
 }

--- a/src/orden-produccion/entity.ts
+++ b/src/orden-produccion/entity.ts
@@ -6,13 +6,22 @@ export class OrdenProduccion {
   id: string;
 
   @Column()
-  codigo: string;
+  numero: string;
 
-  @Column("simple-array")
-  pasos: string[];
+  @Column()
+  producto: string;
 
-  @Column({ default: 0 })
-  progreso: number;
+  @Column('int')
+  cantidadAProducir: number;
+
+  @Column({ type: 'date' })
+  fechaOrden: string;
+
+  @Column({ type: 'date' })
+  fechaVencimiento: string;
+
+  @Column()
+  estado: string;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/orden-produccion/orden-produccion.controller.ts
+++ b/src/orden-produccion/orden-produccion.controller.ts
@@ -1,7 +1,6 @@
-import { Controller, Post, Get, Param, Patch, Body } from '@nestjs/common'
+import { Controller, Post, Get, Param, Body, Put, Delete } from '@nestjs/common'
 import { OrdenProduccionService } from './orden-produccion.service'
 import { CrearOrdenDto } from './dto/crear-orden.dto'
-import { ActualizarProgresoDto } from './dto/actualizar-progreso.dto'
 
 @Controller('ordenes')
 export class OrdenProduccionController {
@@ -22,13 +21,13 @@ export class OrdenProduccionController {
     return this.service.obtenerPorId(id)
   }
 
-  @Get(':id/pasos')
-  obtenerPasos(@Param('id') id: string) {
-    return this.service.obtenerPasos(id)
+  @Put(':id')
+  actualizar(@Param('id') id: string, @Body() dto: CrearOrdenDto) {
+    return this.service.actualizar(id, dto)
   }
 
-  @Patch(':id/progreso')
-  actualizarProgreso(@Param('id') id: string, @Body() dto: ActualizarProgresoDto) {
-    return this.service.actualizarProgreso(id, dto)
+  @Delete(':id')
+  eliminar(@Param('id') id: string) {
+    return this.service.eliminar(id)
   }
 }

--- a/src/orden-produccion/orden-produccion.service.ts
+++ b/src/orden-produccion/orden-produccion.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { OrdenProduccion } from './entity'
 import { CrearOrdenDto } from './dto/crear-orden.dto'
-import { ActualizarProgresoDto } from './dto/actualizar-progreso.dto'
+import { CrearOrdenDto as UpdateOrdenDto } from './dto/crear-orden.dto'
 
 @Injectable()
 export class OrdenProduccionService {
@@ -24,16 +24,16 @@ export class OrdenProduccionService {
     return orden
   }
 
-  async obtenerPasos(id: string) {
-    const orden = await this.repo.findOne({ where: { id } })
+  async actualizar(id: string, dto: UpdateOrdenDto) {
+    const orden = await this.repo.preload({ id, ...dto })
     if (!orden) throw new NotFoundException('Orden no encontrada')
-    return orden.pasos
+    return this.repo.save(orden)
   }
 
-  async actualizarProgreso(id: string, dto: ActualizarProgresoDto) {
+  async eliminar(id: string) {
     const orden = await this.repo.findOne({ where: { id } })
     if (!orden) throw new NotFoundException('Orden no encontrada')
-    orden.progreso = dto.progreso
-    return this.repo.save(orden)
+    await this.repo.remove(orden)
+    return { deleted: true }
   }
 }

--- a/src/paso-produccion/dto/create-paso-produccion.dto.ts
+++ b/src/paso-produccion/dto/create-paso-produccion.dto.ts
@@ -1,16 +1,21 @@
-import { IsString, IsNotEmpty, IsNumber, IsIn } from 'class-validator'
+import { IsString, IsNotEmpty, IsNumber, IsIn, IsUUID } from 'class-validator'
 
 export class CreatePasoProduccionDto {
   @IsString()
   @IsNotEmpty()
   nombre: string
 
+  @IsUUID()
+  orden: string
+
   @IsString()
-  @IsNotEmpty()
-  ordenProduccionId: string
+  codigoInterno: string
 
   @IsNumber()
-  numeroPaso: number
+  cantidadRequerida: number
+
+  @IsNumber()
+  cantidadProducida: number
 
   @IsString()
   @IsIn(['pendiente', 'en_progreso', 'completado'])

--- a/src/paso-produccion/dto/update-paso-produccion.dto.ts
+++ b/src/paso-produccion/dto/update-paso-produccion.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsNotEmpty, IsNumber, IsIn } from 'class-validator'
+import { IsOptional, IsString, IsNotEmpty, IsNumber, IsIn, IsUUID } from 'class-validator'
 
 export class UpdatePasoProduccionDto {
   @IsOptional()
@@ -7,13 +7,20 @@ export class UpdatePasoProduccionDto {
   nombre?: string
 
   @IsOptional()
+  @IsUUID()
+  orden?: string
+
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  ordenProduccionId?: string
+  codigoInterno?: string
 
   @IsOptional()
   @IsNumber()
-  numeroPaso?: number
+  cantidadRequerida?: number
+
+  @IsOptional()
+  @IsNumber()
+  cantidadProducida?: number
 
   @IsOptional()
   @IsString()

--- a/src/paso-produccion/paso-produccion.controller.ts
+++ b/src/paso-produccion/paso-produccion.controller.ts
@@ -1,12 +1,34 @@
-import { Controller, Get, Param } from '@nestjs/common'
+import { Controller, Get, Param, Post, Body, Put, Delete } from '@nestjs/common'
 import { PasoProduccionService } from './paso-produccion.service'
+import { CreatePasoProduccionDto } from './dto/create-paso-produccion.dto'
+import { UpdatePasoProduccionDto } from './dto/update-paso-produccion.dto'
 
 @Controller('pasos')
 export class PasoProduccionController {
   constructor(private readonly pasoService: PasoProduccionService) {}
 
+  @Post()
+  create(@Body() dto: CreatePasoProduccionDto) {
+    return this.pasoService.create(dto)
+  }
+
+  @Get()
+  findAll() {
+    return this.pasoService.findAll()
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.pasoService.findOne(id)
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdatePasoProduccionDto) {
+    return this.pasoService.update(id, dto)
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.pasoService.remove(id)
   }
 }

--- a/src/paso-produccion/paso-produccion.entity.ts
+++ b/src/paso-produccion/paso-produccion.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { OrdenProduccion } from '../orden-produccion/entity';
 
 @Entity()
 export class PasoProduccion {
@@ -8,11 +9,18 @@ export class PasoProduccion {
   @Column()
   nombre: string;
 
-  @Column()
-  ordenProduccionId: string;
+  @ManyToOne(() => OrdenProduccion, { nullable: false })
+  @JoinColumn({ name: 'ordenId' })
+  orden: OrdenProduccion;
 
   @Column()
-  numeroPaso: number;
+  codigoInterno: string;
+
+  @Column('int')
+  cantidadRequerida: number;
+
+  @Column('int')
+  cantidadProducida: number;
 
   @Column({ default: 'pendiente' })
   estado: 'pendiente' | 'en_progreso' | 'completado';

--- a/src/paso-produccion/paso-produccion.service.ts
+++ b/src/paso-produccion/paso-produccion.service.ts
@@ -2,6 +2,8 @@ import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { PasoProduccion } from './paso-produccion.entity'
+import { CreatePasoProduccionDto } from './dto/create-paso-produccion.dto'
+import { UpdatePasoProduccionDto } from './dto/update-paso-produccion.dto'
 
 @Injectable()
 export class PasoProduccionService {
@@ -9,9 +11,36 @@ export class PasoProduccionService {
     @InjectRepository(PasoProduccion) private readonly repo: Repository<PasoProduccion>
   ) {}
 
+  create(dto: CreatePasoProduccionDto) {
+    const paso = this.repo.create({
+      ...dto,
+      orden: { id: dto.orden } as any,
+    });
+    return this.repo.save(paso);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['orden'] });
+  }
+
   async findOne(id: string) {
     const paso = await this.repo.findOne({ where: { id } });
     if (!paso) throw new NotFoundException('Paso no encontrado');
     return paso;
+  }
+
+  async update(id: string, dto: UpdatePasoProduccionDto) {
+    const paso = await this.repo.findOne({ where: { id } });
+    if (!paso) throw new NotFoundException('Paso no encontrado');
+    if (dto.orden) paso.orden = { id: dto.orden } as any;
+    Object.assign(paso, dto);
+    return this.repo.save(paso);
+  }
+
+  async remove(id: string) {
+    const paso = await this.repo.findOne({ where: { id } });
+    if (!paso) throw new NotFoundException('Paso no encontrado');
+    await this.repo.remove(paso);
+    return { deleted: true };
   }
 }

--- a/src/registro-minuto/dto/create-registro-minuto.dto.ts
+++ b/src/registro-minuto/dto/create-registro-minuto.dto.ts
@@ -1,27 +1,15 @@
-import { IsNotEmpty, IsString, IsNumber, IsDate } from 'class-validator'
+import { IsNotEmpty, IsString, IsNumber, IsDate, IsUUID } from 'class-validator'
 
 export class CreateRegistroMinutoDto {
-  @IsNotEmpty()
-  @IsString()
-  recursoId: string
+  @IsUUID()
+  sesionTrabajo: string
 
-  @IsNotEmpty()
-  @IsString()
-  ordenId: string
-
-  @IsNotEmpty()
-  @IsString()
-  pasoId: string
-
-  @IsNotEmpty()
-  @IsNumber()
-  cantidad: number
-
-  @IsNotEmpty()
-  @IsNumber()
-  pedalazos: number
-
-  @IsNotEmpty()
   @IsDate()
-  timestamp: Date
+  minutoInicio: Date
+
+  @IsNumber()
+  pedaleadas: number
+
+  @IsNumber()
+  piezasContadas: number
 }

--- a/src/registro-minuto/registro-minuto.entity.ts
+++ b/src/registro-minuto/registro-minuto.entity.ts
@@ -1,25 +1,21 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, BaseEntity } from 'typeorm'
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEntity } from 'typeorm'
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity'
 
 @Entity('registro_minuto')
 export class RegistroMinuto extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string
 
-  @Column()
-  recursoId: string
+  @ManyToOne(() => SesionTrabajo, { nullable: false })
+  @JoinColumn({ name: 'sesionTrabajoId' })
+  sesionTrabajo: SesionTrabajo
 
-  @Column()
-  ordenId: string
-
-  @Column()
-  pasoId: string
+  @Column({ type: 'timestamp' })
+  minutoInicio: Date
 
   @Column('int')
-  cantidad: number
+  pedaleadas: number
 
   @Column('int')
-  pedalazos: number
-
-  @CreateDateColumn()
-  timestamp: Date
+  piezasContadas: number
 }

--- a/src/registro-minuto/registro-minuto.service.ts
+++ b/src/registro-minuto/registro-minuto.service.ts
@@ -6,18 +6,18 @@ import { CreateRegistroMinutoDto } from './dto/create-registro-minuto.dto'
 
 @Injectable()
 export class RegistroMinutoService {
-  private memoria: Map<string, { cantidad: number; pedalazos: number }> = new Map()
+  private memoria: Map<string, { pedaleadas: number; piezasContadas: number }> = new Map()
 
   constructor(
     @InjectRepository(RegistroMinuto)
     private readonly repo: Repository<RegistroMinuto>,
   ) {}
 
-  acumular(recursoId: string, ordenId: string, pasoId: string, cantidad: number, pedalazos: number) {
-    const clave = `${recursoId}-${ordenId}-${pasoId}`
-    const actual = this.memoria.get(clave) || { cantidad: 0, pedalazos: 0 }
-    actual.cantidad += cantidad
-    actual.pedalazos += pedalazos
+  acumular(sesionTrabajoId: string, pedaleadas: number, piezasContadas: number) {
+    const clave = sesionTrabajoId
+    const actual = this.memoria.get(clave) || { pedaleadas: 0, piezasContadas: 0 }
+    actual.pedaleadas += pedaleadas
+    actual.piezasContadas += piezasContadas
     this.memoria.set(clave, actual)
   }
 
@@ -25,9 +25,8 @@ export class RegistroMinutoService {
     const fecha = new Date()
     const registros: CreateRegistroMinutoDto[] = []
 
-    for (const [clave, data] of this.memoria.entries()) {
-      const [recursoId, ordenId, pasoId] = clave.split('-')
-      registros.push({ recursoId, ordenId, pasoId, ...data, timestamp: fecha })
+    for (const [sesionTrabajo, data] of this.memoria.entries()) {
+      registros.push({ sesionTrabajo, ...data, minutoInicio: fecha })
     }
 
     if (registros.length > 0) await this.repo.save(registros)

--- a/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
+++ b/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
@@ -1,0 +1,21 @@
+import { IsUUID, IsEnum, IsDate, IsOptional } from 'class-validator';
+import { EstadoSesionTrabajo } from '../sesion-trabajo.entity';
+
+export class CreateSesionTrabajoDto {
+  @IsUUID()
+  recurso: string;
+
+  @IsUUID()
+  pasoOrden: string;
+
+  @IsDate()
+  fechaInicio: Date;
+
+  @IsOptional()
+  @IsDate()
+  fechaFin?: Date;
+
+  @IsOptional()
+  @IsEnum(EstadoSesionTrabajo)
+  estado?: EstadoSesionTrabajo;
+}

--- a/src/sesion-trabajo/dto/update-sesion-trabajo.dto.ts
+++ b/src/sesion-trabajo/dto/update-sesion-trabajo.dto.ts
@@ -1,0 +1,24 @@
+import { IsUUID, IsEnum, IsDate, IsOptional } from 'class-validator';
+import { EstadoSesionTrabajo } from '../sesion-trabajo.entity';
+
+export class UpdateSesionTrabajoDto {
+  @IsOptional()
+  @IsUUID()
+  recurso?: string;
+
+  @IsOptional()
+  @IsUUID()
+  pasoOrden?: string;
+
+  @IsOptional()
+  @IsDate()
+  fechaInicio?: Date;
+
+  @IsOptional()
+  @IsDate()
+  fechaFin?: Date;
+
+  @IsOptional()
+  @IsEnum(EstadoSesionTrabajo)
+  estado?: EstadoSesionTrabajo;
+}

--- a/src/sesion-trabajo/sesion-trabajo.controller.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Param, Body, Put, Delete } from '@nestjs/common';
+import { SesionTrabajoService } from './sesion-trabajo.service';
+import { CreateSesionTrabajoDto } from './dto/create-sesion-trabajo.dto';
+import { UpdateSesionTrabajoDto } from './dto/update-sesion-trabajo.dto';
+
+@Controller('sesiones-trabajo')
+export class SesionTrabajoController {
+  constructor(private readonly service: SesionTrabajoService) {}
+
+  @Post()
+  create(@Body() dto: CreateSesionTrabajoDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateSesionTrabajoDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/sesion-trabajo/sesion-trabajo.entity.ts
+++ b/src/sesion-trabajo/sesion-trabajo.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEntity } from 'typeorm';
+import { Recurso } from '../recurso/recurso.entity';
+import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
+
+export enum EstadoSesionTrabajo {
+  ACTIVA = 'activa',
+  FINALIZADA = 'finalizada',
+}
+
+@Entity('sesion_trabajo')
+export class SesionTrabajo extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Recurso, { nullable: false })
+  @JoinColumn({ name: 'recursoId' })
+  recurso: Recurso;
+
+  @ManyToOne(() => PasoProduccion, { nullable: false })
+  @JoinColumn({ name: 'pasoOrdenId' })
+  pasoOrden: PasoProduccion;
+
+  @Column({ type: 'timestamp' })
+  fechaInicio: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  fechaFin: Date;
+
+  @Column({ type: 'enum', enum: EstadoSesionTrabajo, default: EstadoSesionTrabajo.ACTIVA })
+  estado: EstadoSesionTrabajo;
+}

--- a/src/sesion-trabajo/sesion-trabajo.module.ts
+++ b/src/sesion-trabajo/sesion-trabajo.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SesionTrabajo } from './sesion-trabajo.entity';
+import { SesionTrabajoService } from './sesion-trabajo.service';
+import { SesionTrabajoController } from './sesion-trabajo.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SesionTrabajo])],
+  providers: [SesionTrabajoService],
+  controllers: [SesionTrabajoController],
+})
+export class SesionTrabajoModule {}

--- a/src/sesion-trabajo/sesion-trabajo.service.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SesionTrabajo } from './sesion-trabajo.entity';
+import { CreateSesionTrabajoDto } from './dto/create-sesion-trabajo.dto';
+import { UpdateSesionTrabajoDto } from './dto/update-sesion-trabajo.dto';
+
+@Injectable()
+export class SesionTrabajoService {
+  constructor(
+    @InjectRepository(SesionTrabajo)
+    private readonly repo: Repository<SesionTrabajo>,
+  ) {}
+
+  create(dto: CreateSesionTrabajoDto) {
+    const sesion = this.repo.create({
+      ...dto,
+      recurso: { id: dto.recurso } as any,
+      pasoOrden: { id: dto.pasoOrden } as any,
+    });
+    return this.repo.save(sesion);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['recurso', 'pasoOrden'] });
+  }
+
+  async findOne(id: string) {
+    const sesion = await this.repo.findOne({ where: { id }, relations: ['recurso', 'pasoOrden'] });
+    if (!sesion) throw new NotFoundException('Sesión no encontrada');
+    return sesion;
+  }
+
+  async update(id: string, dto: UpdateSesionTrabajoDto) {
+    const sesion = await this.repo.findOne({ where: { id } });
+    if (!sesion) throw new NotFoundException('Sesión no encontrada');
+    if (dto.recurso) sesion.recurso = { id: dto.recurso } as any;
+    if (dto.pasoOrden) sesion.pasoOrden = { id: dto.pasoOrden } as any;
+    Object.assign(sesion, dto);
+    return this.repo.save(sesion);
+  }
+
+  async remove(id: string) {
+    const sesion = await this.repo.findOne({ where: { id } });
+    if (!sesion) throw new NotFoundException('Sesión no encontrada');
+    await this.repo.remove(sesion);
+    return { deleted: true };
+  }
+}


### PR DESCRIPTION
## Summary
- align OrdenProduccion model with backend diagram
- expand PasoProduccion properties
- refactor RegistroMinuto to track sessions
- create EstadoRecurso module
- add SesionTrabajo, Empresa and MaterialOrden modules
- wire new modules into AppModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa7a2bed48325a3c75083a8213598