### PR TITLE
Add join table for session and order steps

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { ProductividadModule } from './productividad/productividad.module';
 import { AuthModule } from './auth/auth.module';
 import { SesionTrabajoModule } from './sesion-trabajo/sesion-trabajo.module';
 import { EstadoRecursoModule } from './estado-recurso/estado-recurso.module';
+import { SesionTrabajoPasoModule } from './sesion-trabajo-paso/sesion-trabajo-paso.module';
 import { EmpresaModule } from './empresa/empresa.module';
 import { MaterialOrdenModule } from './material-orden/material-orden.module';
 import * as fs from 'fs';
@@ -61,6 +62,7 @@ import * as path from 'path';
   RegistroMinutoModule,
 
   SesionTrabajoModule,
+  SesionTrabajoPasoModule,
 
   EstadoRecursoModule,
 

--- a/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
@@ -1,0 +1,9 @@
+import { IsUUID } from 'class-validator';
+
+export class CreateSesionTrabajoPasoDto {
+  @IsUUID()
+  sesionTrabajo: string;
+
+  @IsUUID()
+  pasoOrden: string;
+}

--- a/src/sesion-trabajo-paso/dto/update-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/update-sesion-trabajo-paso.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID, IsOptional } from 'class-validator';
+
+export class UpdateSesionTrabajoPasoDto {
+  @IsOptional()
+  @IsUUID()
+  sesionTrabajo?: string;
+
+  @IsOptional()
+  @IsUUID()
+  pasoOrden?: string;
+}

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.controller.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Param, Body, Put, Delete } from '@nestjs/common';
+import { SesionTrabajoPasoService } from './sesion-trabajo-paso.service';
+import { CreateSesionTrabajoPasoDto } from './dto/create-sesion-trabajo-paso.dto';
+import { UpdateSesionTrabajoPasoDto } from './dto/update-sesion-trabajo-paso.dto';
+
+@Controller('sesion-trabajo-pasos')
+export class SesionTrabajoPasoController {
+  constructor(private readonly service: SesionTrabajoPasoService) {}
+
+  @Post()
+  create(@Body() dto: CreateSesionTrabajoPasoDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateSesionTrabajoPasoDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, BaseEntity } from 'typeorm';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
+
+@Entity('sesion_trabajo_paso')
+export class SesionTrabajoPaso extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => SesionTrabajo, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'sesionTrabajoId' })
+  sesionTrabajo: SesionTrabajo;
+
+  @ManyToOne(() => PasoProduccion, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'pasoOrdenId' })
+  pasoOrden: PasoProduccion;
+}

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.module.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SesionTrabajoPaso } from './sesion-trabajo-paso.entity';
+import { SesionTrabajoPasoService } from './sesion-trabajo-paso.service';
+import { SesionTrabajoPasoController } from './sesion-trabajo-paso.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SesionTrabajoPaso])],
+  providers: [SesionTrabajoPasoService],
+  controllers: [SesionTrabajoPasoController],
+})
+export class SesionTrabajoPasoModule {}

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SesionTrabajoPaso } from './sesion-trabajo-paso.entity';
+import { CreateSesionTrabajoPasoDto } from './dto/create-sesion-trabajo-paso.dto';
+import { UpdateSesionTrabajoPasoDto } from './dto/update-sesion-trabajo-paso.dto';
+
+@Injectable()
+export class SesionTrabajoPasoService {
+  constructor(
+    @InjectRepository(SesionTrabajoPaso)
+    private readonly repo: Repository<SesionTrabajoPaso>,
+  ) {}
+
+  create(dto: CreateSesionTrabajoPasoDto) {
+    const entity = this.repo.create({
+      sesionTrabajo: { id: dto.sesionTrabajo } as any,
+      pasoOrden: { id: dto.pasoOrden } as any,
+    });
+    return this.repo.save(entity);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['sesionTrabajo', 'pasoOrden'] });
+  }
+
+  async findOne(id: string) {
+    const entity = await this.repo.findOne({ where: { id }, relations: ['sesionTrabajo', 'pasoOrden'] });
+    if (!entity) throw new NotFoundException('Relación no encontrada');
+    return entity;
+  }
+
+  async update(id: string, dto: UpdateSesionTrabajoPasoDto) {
+    const entity = await this.repo.findOne({ where: { id } });
+    if (!entity) throw new NotFoundException('Relación no encontrada');
+    if (dto.sesionTrabajo) entity.sesionTrabajo = { id: dto.sesionTrabajo } as any;
+    if (dto.pasoOrden) entity.pasoOrden = { id: dto.pasoOrden } as any;
+    return this.repo.save(entity);
+  }
+
+  async remove(id: string) {
+    const entity = await this.repo.findOne({ where: { id } });
+    if (!entity) throw new NotFoundException('Relación no encontrada');
+    await this.repo.remove(entity);
+    return { deleted: true };
+  }
+}

--- a/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
+++ b/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
@@ -5,9 +5,6 @@ export class CreateSesionTrabajoDto {
   @IsUUID()
   recurso: string;
 
-  @IsUUID()
-  pasosOrden: string;
-
   @IsDateString()
   fechaInicio: Date;
 

--- a/src/sesion-trabajo/dto/update-sesion-trabajo.dto.ts
+++ b/src/sesion-trabajo/dto/update-sesion-trabajo.dto.ts
@@ -7,10 +7,6 @@ export class UpdateSesionTrabajoDto {
   recurso?: string;
 
   @IsOptional()
-  @IsUUID()
-  pasosOrden?: string;
-
-  @IsOptional()
   @IsDate()
   fechaInicio?: Date;
 

--- a/src/sesion-trabajo/sesion-trabajo.entity.ts
+++ b/src/sesion-trabajo/sesion-trabajo.entity.ts
@@ -1,6 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEntity, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEntity } from 'typeorm';
 import { Recurso } from '../recurso/recurso.entity';
-import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
 
 export enum EstadoSesionTrabajo {
   ACTIVA = 'activa',
@@ -15,15 +14,6 @@ export class SesionTrabajo extends BaseEntity {
   @ManyToOne(() => Recurso, { nullable: false })
   @JoinColumn({ name: 'recursoId' })
   recurso: Recurso;
-
-  @ManyToMany(() => PasoProduccion)
-  @JoinTable({
-    name: 'sesion_trabajo_pasos',
-    joinColumn: { name: 'sesionTrabajoId', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'pasosOrdenId', referencedColumnName: 'id' },
-  })
-  pasosOrden: PasoProduccion[];
-
   @Column({ type: 'timestamp' })
   fechaInicio: Date;
 

--- a/src/sesion-trabajo/sesion-trabajo.service.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.ts
@@ -16,17 +16,16 @@ export class SesionTrabajoService {
     const sesion = this.repo.create({
       ...dto,
       recurso: { id: dto.recurso } as any,
-      pasosOrden: { id: dto.pasosOrden } as any,
     });
     return this.repo.save(sesion);
   }
 
   findAll() {
-    return this.repo.find({ relations: ['recurso', 'pasosOrden'] });
+    return this.repo.find({ relations: ['recurso'] });
   }
 
   async findOne(id: string) {
-    const sesion = await this.repo.findOne({ where: { id }, relations: ['recurso', 'pasosOrden'] });
+    const sesion = await this.repo.findOne({ where: { id }, relations: ['recurso'] });
     if (!sesion) throw new NotFoundException('Sesión no encontrada');
     return sesion;
   }
@@ -35,7 +34,6 @@ export class SesionTrabajoService {
     const sesion = await this.repo.findOne({ where: { id } });
     if (!sesion) throw new NotFoundException('Sesión no encontrada');
     if (dto.recurso) sesion.recurso = { id: dto.recurso } as any;
-    if (dto.pasosOrden) sesion.pasosOrden = { id: dto.pasosOrden } as any;
     Object.assign(sesion, dto);
     return this.repo.save(sesion);
   }


### PR DESCRIPTION
## Summary
- create SesionTrabajoPaso entity to link sessions and steps
- expose CRUD endpoints for the relation
- remove direct many-to-many from SesionTrabajo
- adjust DTOs and service logic
- register new module in `AppModule`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687db194d7b4832598ab88216c823700