### PR TITLE
Add automatic minute save process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/mongoose": "^11.0.3",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/typeorm": "^11.0.0",
         "async-mutex": "^0.5.0",
         "class-transformer": "^0.5.1",
@@ -2173,6 +2174,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.0.tgz",
@@ -2934,6 +2948,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4863,6 +4883,19 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7843,6 +7876,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.25"
+    "typeorm": "^0.3.25",
+    "@nestjs/schedule": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TrabajadorModule } from './trabajador/trabajador.module';
 import { MaquinaModule } from './maquina/maquina.module';
 import { OrdenProduccionModule } from './orden-produccion/orden-produccion.module';
@@ -24,6 +25,8 @@ import * as path from 'path';
 
 @Module({
   imports: [
+
+  ScheduleModule.forRoot(),
 
   TypeOrmModule.forRoot({
     type: 'postgres',

--- a/src/registro-minuto/registro-minuto.service.ts
+++ b/src/registro-minuto/registro-minuto.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { RegistroMinuto } from './registro-minuto.entity'
@@ -15,6 +16,11 @@ export class RegistroMinutoService {
     @InjectRepository(RegistroMinuto)
     private readonly repo: Repository<RegistroMinuto>,
   ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async procesarAutomatico() {
+    await this.guardarYLimpiar()
+  }
 
   async acumular(sesionTrabajoId: string, tipo: 'pedal' | 'pieza', minutoInicio: string) {
   await this.mutex.runExclusive(() => {


### PR DESCRIPTION
## Summary
- add `@nestjs/schedule` dependency
- initialize `ScheduleModule` in `AppModule`
- run automatic minute save via a Cron job

## Testing
- `npm run build` *(fails: `nest` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d0e43c8083259fbd4b3b7a8957a7