### PR TITLE
Fix crypto undefined error in NestJS scheduler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import * as nodeCrypto from 'crypto';
+
+(global as any).crypto = (global as any).crypto || nodeCrypto;
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
## Summary
- polyfill global `crypto` object when starting the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e56c5c0483258fd34bd517d47027