### PR TITLE
Remove fechaInicio parameter for sessions

### DIFF
--- a/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
+++ b/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
@@ -8,9 +8,6 @@ export class CreateSesionTrabajoDto {
   @IsUUID()
   maquina: string;
 
-  @IsDateString()
-  fechaInicio: Date;
-
   @IsOptional()
   @IsDateString()
   fechaFin?: Date;


### PR DESCRIPTION
## Summary
- create sessions with current UTC time
- stop using `TimezoneService` in session service

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887dce9097c83258dc8213bfa22d4e0