### PR TITLE
Implement step-session tracking

### DIFF
--- a/src/paso-produccion/paso-produccion.entity.ts
+++ b/src/paso-produccion/paso-produccion.entity.ts
@@ -1,4 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { OrdenProduccion } from '../orden-produccion/entity';
 
 @Entity()
@@ -9,7 +17,7 @@ export class PasoProduccion {
   @Column()
   nombre: string;
 
-  @ManyToOne(() => OrdenProduccion, { nullable: false })
+  @ManyToOne(() => OrdenProduccion, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'ordenId' })
   orden: OrdenProduccion;
 

--- a/src/registro-minuto/registro-minuto.module.ts
+++ b/src/registro-minuto/registro-minuto.module.ts
@@ -1,14 +1,14 @@
-import { Module } from '@nestjs/common'
-import { TypeOrmModule } from '@nestjs/typeorm'
-import { RegistroMinutoService } from './registro-minuto.service'
-import { RegistroMinuto } from './registro-minuto.entity'
-import { RegistroMinutoController } from './registro-minuto.controller'
-
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RegistroMinutoService } from './registro-minuto.service';
+import { RegistroMinuto } from './registro-minuto.entity';
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
+import { RegistroMinutoController } from './registro-minuto.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RegistroMinuto])],
+  imports: [TypeOrmModule.forFeature([RegistroMinuto, SesionTrabajoPaso])],
   providers: [RegistroMinutoService],
   controllers: [RegistroMinutoController],
-  exports: [RegistroMinutoService]
+  exports: [RegistroMinutoService],
 })
 export class RegistroMinutoModule {}

--- a/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
@@ -1,4 +1,5 @@
-import { IsUUID } from 'class-validator';
+import { IsUUID, IsNumber, IsOptional, IsIn } from 'class-validator';
+import { EstadoSesionTrabajoPaso } from '../sesion-trabajo-paso.entity';
 
 export class CreateSesionTrabajoPasoDto {
   @IsUUID()
@@ -6,4 +7,15 @@ export class CreateSesionTrabajoPasoDto {
 
   @IsUUID()
   pasoOrden: string;
+
+  @IsNumber()
+  cantidadAsignada: number;
+
+  @IsOptional()
+  @IsNumber()
+  cantidadProducida?: number;
+
+  @IsOptional()
+  @IsIn(['activo', 'pausado', 'finalizado'])
+  estado?: EstadoSesionTrabajoPaso;
 }

--- a/src/sesion-trabajo-paso/dto/update-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/update-sesion-trabajo-paso.dto.ts
@@ -1,4 +1,5 @@
-import { IsUUID, IsOptional } from 'class-validator';
+import { IsUUID, IsOptional, IsNumber, IsIn } from 'class-validator';
+import { EstadoSesionTrabajoPaso } from '../sesion-trabajo-paso.entity';
 
 export class UpdateSesionTrabajoPasoDto {
   @IsOptional()
@@ -8,4 +9,16 @@ export class UpdateSesionTrabajoPasoDto {
   @IsOptional()
   @IsUUID()
   pasoOrden?: string;
+
+  @IsOptional()
+  @IsNumber()
+  cantidadAsignada?: number;
+
+  @IsOptional()
+  @IsNumber()
+  cantidadProducida?: number;
+
+  @IsOptional()
+  @IsIn(['activo', 'pausado', 'finalizado'])
+  estado?: EstadoSesionTrabajoPaso;
 }

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
@@ -1,6 +1,19 @@
-import { Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, BaseEntity } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  BaseEntity,
+  Column,
+} from 'typeorm';
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
 import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
+
+export enum EstadoSesionTrabajoPaso {
+  ACTIVO = 'activo',
+  PAUSADO = 'pausado',
+  FINALIZADO = 'finalizado',
+}
 
 @Entity('sesion_trabajo_paso')
 export class SesionTrabajoPaso extends BaseEntity {
@@ -14,4 +27,17 @@ export class SesionTrabajoPaso extends BaseEntity {
   @ManyToOne(() => PasoProduccion, { nullable: false, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'pasoOrdenId' })
   pasoOrden: PasoProduccion;
+
+  @Column('int')
+  cantidadAsignada: number;
+
+  @Column('int', { default: 0 })
+  cantidadProducida: number;
+
+  @Column({
+    type: 'enum',
+    enum: EstadoSesionTrabajoPaso,
+    default: EstadoSesionTrabajoPaso.PAUSADO,
+  })
+  estado: EstadoSesionTrabajoPaso;
 }


### PR DESCRIPTION
## Summary
- create enum for states in `SesionTrabajoPaso`
- add quantities and state columns
- allow setting fields via DTOs and services
- cascade delete on `PasoProduccion`
- update `RegistroMinutoService` to increment produced amount for the active step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f06aebf88325b7c6843097a0c5b2