### PR TITLE
Handle production order steps

### DIFF
--- a/src/orden-produccion/dto/actualizar-orden.dto.ts
+++ b/src/orden-produccion/dto/actualizar-orden.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CrearOrdenDto } from './crear-orden.dto';
+
+export class ActualizarOrdenDto extends PartialType(CrearOrdenDto) {}

--- a/src/orden-produccion/dto/crear-orden.dto.ts
+++ b/src/orden-produccion/dto/crear-orden.dto.ts
@@ -1,5 +1,13 @@
-import { IsString, IsInt, IsDate } from 'class-validator'
+import {
+  IsString,
+  IsInt,
+  IsDate,
+  IsUUID,
+  ValidateNested,
+  IsArray,
+} from 'class-validator'
 import { Type } from 'class-transformer'
+import { PasoOrdenDto } from './paso-orden.dto'
 
 export class CrearOrdenDto {
   @IsString()
@@ -21,4 +29,12 @@ export class CrearOrdenDto {
 
   @IsString()
   estado: string
+
+  @IsUUID()
+  maquina: string
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PasoOrdenDto)
+  pasos: PasoOrdenDto[]
 }

--- a/src/orden-produccion/dto/paso-orden.dto.ts
+++ b/src/orden-produccion/dto/paso-orden.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsNotEmpty, IsNumber, IsIn, IsOptional } from 'class-validator';
+import { EstadoPaso } from '../../paso-produccion/dto/create-paso-produccion.dto';
+
+export class PasoOrdenDto {
+  @IsString()
+  @IsNotEmpty()
+  nombre: string;
+
+  @IsString()
+  codigoInterno: string;
+
+  @IsNumber()
+  cantidadRequerida: number;
+
+  @IsOptional()
+  @IsNumber()
+  cantidadProducida?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['pendiente', 'en_progreso', 'completado'])
+  estado?: EstadoPaso;
+}

--- a/src/orden-produccion/orden-produccion.controller.ts
+++ b/src/orden-produccion/orden-produccion.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Get, Param, Body, Put, Delete } from '@nestjs/common'
 import { OrdenProduccionService } from './orden-produccion.service'
 import { CrearOrdenDto } from './dto/crear-orden.dto'
+import { ActualizarOrdenDto } from './dto/actualizar-orden.dto'
 
 @Controller('ordenes')
 export class OrdenProduccionController {
@@ -22,7 +23,7 @@ export class OrdenProduccionController {
   }
 
   @Put(':id')
-  actualizar(@Param('id') id: string, @Body() dto: CrearOrdenDto) {
+  actualizar(@Param('id') id: string, @Body() dto: ActualizarOrdenDto) {
     return this.service.actualizar(id, dto)
   }
 

--- a/src/orden-produccion/orden-produccion.module.ts
+++ b/src/orden-produccion/orden-produccion.module.ts
@@ -3,9 +3,19 @@ import { OrdenProduccion } from './entity';
 import { Module } from '@nestjs/common';
 import { OrdenProduccionController } from './orden-produccion.controller';
 import { OrdenProduccionService } from './orden-produccion.service';
+import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([OrdenProduccion])],
+  imports: [
+    TypeOrmModule.forFeature([
+      OrdenProduccion,
+      PasoProduccion,
+      SesionTrabajo,
+      SesionTrabajoPaso,
+    ]),
+  ],
   controllers: [OrdenProduccionController],
   providers: [OrdenProduccionService]
 })


### PR DESCRIPTION
## Summary
- support creating production orders with an array of steps
- create DTOs for updating orders and for step data inside orders
- link newly created steps with the active session by machine
- allow editing an order to replace its steps

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888ffc57f708325bccd58edd394b922