### PR TITLE
Implement session validation when creating orders

### DIFF
--- a/src/orden-produccion/orden-produccion.module.ts
+++ b/src/orden-produccion/orden-produccion.module.ts
@@ -6,6 +6,7 @@ import { OrdenProduccionService } from './orden-produccion.service';
 import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
 import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
+import { Maquina } from '../maquina/maquina.entity';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.en
       PasoProduccion,
       SesionTrabajo,
       SesionTrabajoPaso,
+      Maquina,
     ]),
   ],
   controllers: [OrdenProduccionController],


### PR DESCRIPTION
## Summary
- add `Maquina` repository to order module
- validate existence of machine and active session when creating an order
- perform the same validation when updating an order

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/use-at-your-own-risk')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889104c3f648325ab6cf4dd08f92659