### PR TITLE
Use Colombia timezone for timestamps

### DIFF
--- a/src/registro-minuto/registro-minuto.service.ts
+++ b/src/registro-minuto/registro-minuto.service.ts
@@ -61,14 +61,18 @@ export class RegistroMinutoService {
         const [sesionTrabajo, minutoInicio] = clave.split('_');
         registros.push({
           sesionTrabajo,
-          minutoInicio: new Date(minutoInicio).toISOString(),
+          minutoInicio: DateTime.fromISO(minutoInicio, {
+            zone: 'America/Bogota',
+          }).toISO(),
           ...data,
         });
       }
 
       for (const dto of registros) {
         const sesionTrabajoId = dto.sesionTrabajo;
-        const minutoInicio = new Date(dto.minutoInicio);
+        const minutoInicio = DateTime.fromISO(dto.minutoInicio, {
+          zone: 'America/Bogota',
+        }).toJSDate();
 
         const existente = await this.repo.findOne({
           where: {


### PR DESCRIPTION
## Summary
- ensure RegistroMinutoService uses `America/Bogota` when parsing minute timestamps

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889125867808325bfe46f5d822442c9