### PR TITLE
Remove machine dependency from order creation

### DIFF
--- a/src/orden-produccion/dto/actualizar-orden.dto.ts
+++ b/src/orden-produccion/dto/actualizar-orden.dto.ts
@@ -1,4 +1,9 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CrearOrdenDto } from './crear-orden.dto';
+import { IsUUID, IsOptional } from 'class-validator';
 
-export class ActualizarOrdenDto extends PartialType(CrearOrdenDto) {}
+export class ActualizarOrdenDto extends PartialType(CrearOrdenDto) {
+  @IsOptional()
+  @IsUUID()
+  maquina?: string;
+}

--- a/src/orden-produccion/dto/crear-orden.dto.ts
+++ b/src/orden-produccion/dto/crear-orden.dto.ts
@@ -2,7 +2,6 @@ import {
   IsString,
   IsInt,
   IsDate,
-  IsUUID,
   ValidateNested,
   IsArray,
 } from 'class-validator'
@@ -29,9 +28,6 @@ export class CrearOrdenDto {
 
   @IsString()
   estado: string
-
-  @IsUUID()
-  maquina: string
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/registro-minuto/registro-minuto.service.ts
+++ b/src/registro-minuto/registro-minuto.service.ts
@@ -63,7 +63,7 @@ export class RegistroMinutoService {
           sesionTrabajo,
           minutoInicio: DateTime.fromISO(minutoInicio, {
             zone: 'America/Bogota',
-          }).toISO(),
+          }).toISO() as string,
           ...data,
         });
       }


### PR DESCRIPTION
## Summary
- drop `maquina` from `CrearOrdenDto`
- allow machine id only when updating orders
- stop linking newly created orders with active sessions
- fix strict null check in `RegistroMinutoService`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Unable to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_68894c591660832599c6e00d4617b653