### PR TITLE
Implement order status updates

### DIFF
--- a/src/orden-produccion/dto/crear-orden.dto.ts
+++ b/src/orden-produccion/dto/crear-orden.dto.ts
@@ -26,8 +26,6 @@ export class CrearOrdenDto {
   @IsDate()
   fechaVencimiento: Date
 
-  @IsString()
-  estado: string
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/orden-produccion/dto/paso-orden.dto.ts
+++ b/src/orden-produccion/dto/paso-orden.dto.ts
@@ -1,5 +1,5 @@
-import { IsString, IsNotEmpty, IsNumber, IsIn, IsOptional } from 'class-validator';
-import { EstadoPaso } from '../../paso-produccion/dto/create-paso-produccion.dto';
+import { IsString, IsNotEmpty, IsNumber, IsOptional, IsEnum } from 'class-validator';
+import { EstadoPasoOrden } from '../../paso-produccion/paso-produccion.entity';
 
 export class PasoOrdenDto {
   @IsString()
@@ -17,7 +17,6 @@ export class PasoOrdenDto {
   cantidadProducida?: number;
 
   @IsOptional()
-  @IsString()
-  @IsIn(['pendiente', 'en_progreso', 'completado'])
-  estado?: EstadoPaso;
+  @IsEnum(EstadoPasoOrden)
+  estado?: EstadoPasoOrden;
 }

--- a/src/orden-produccion/entity.ts
+++ b/src/orden-produccion/entity.ts
@@ -1,4 +1,17 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum EstadoOrdenProduccion {
+  PENDIENTE = 'pendiente',
+  ACTIVA = 'activa',
+  PAUSADA = 'pausada',
+  FINALIZADA = 'finalizada',
+}
 
 @Entity()
 export class OrdenProduccion {
@@ -20,8 +33,12 @@ export class OrdenProduccion {
   @Column({ type: 'date' })
   fechaVencimiento: Date;
 
-  @Column()
-  estado: string;
+  @Column({
+    type: 'enum',
+    enum: EstadoOrdenProduccion,
+    default: EstadoOrdenProduccion.PENDIENTE,
+  })
+  estado: EstadoOrdenProduccion;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/orden-produccion/orden-produccion.service.ts
+++ b/src/orden-produccion/orden-produccion.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
-import { OrdenProduccion } from './entity'
+import { OrdenProduccion, EstadoOrdenProduccion } from './entity'
 import { CrearOrdenDto } from './dto/crear-orden.dto'
 import { ActualizarOrdenDto } from './dto/actualizar-orden.dto'
 import { PasoOrdenDto } from './dto/paso-orden.dto'
-import { PasoProduccion } from '../paso-produccion/paso-produccion.entity'
+import { PasoProduccion, EstadoPasoOrden } from '../paso-produccion/paso-produccion.entity'
 import {
   SesionTrabajo,
   EstadoSesionTrabajo,
@@ -38,7 +38,11 @@ export class OrdenProduccionService {
     if (existente) throw new NotFoundException('Ya existe una orden con ese número');
 
 
-    const nueva = this.repo.create({ ...datosOrden, numero });
+    const nueva = this.repo.create({
+      ...datosOrden,
+      numero,
+      estado: EstadoOrdenProduccion.PENDIENTE,
+    });
     const orden = await this.repo.save(nueva);
 
     if (pasos?.length) {
@@ -46,7 +50,7 @@ export class OrdenProduccionService {
         const paso = this.pasoRepo.create({
           ...pasoDto,
           cantidadProducida: pasoDto.cantidadProducida ?? 0,
-          estado: (pasoDto.estado as any) ?? 'pendiente',
+          estado: pasoDto.estado ?? EstadoPasoOrden.PENDIENTE,
           orden,
         });
         await this.pasoRepo.save(paso);
@@ -102,7 +106,7 @@ export class OrdenProduccionService {
         const paso = this.pasoRepo.create({
           ...pasoDto,
           cantidadProducida: pasoDto.cantidadProducida ?? 0,
-          estado: (pasoDto.estado as any) ?? 'pendiente',
+          estado: pasoDto.estado ?? EstadoPasoOrden.PENDIENTE,
           orden,
         });
         const pasoGuardado = await this.pasoRepo.save(paso);

--- a/src/paso-produccion/dto/create-paso-produccion.dto.ts
+++ b/src/paso-produccion/dto/create-paso-produccion.dto.ts
@@ -1,6 +1,5 @@
-import { IsString, IsNotEmpty, IsNumber, IsIn, IsUUID } from 'class-validator'
-
-export type EstadoPaso = 'pendiente' | 'en_progreso' | 'completado';
+import { IsString, IsNotEmpty, IsNumber, IsUUID, IsOptional, IsEnum } from 'class-validator'
+import { EstadoPasoOrden } from '../paso-produccion.entity'
 
 export class CreatePasoProduccionDto {
   @IsString()
@@ -16,10 +15,11 @@ export class CreatePasoProduccionDto {
   @IsNumber()
   cantidadRequerida: number
 
+  @IsOptional()
   @IsNumber()
-  cantidadProducida: number
+  cantidadProducida?: number
 
-  @IsString()
-  @IsIn(['pendiente', 'en_progreso', 'completado'])
-  estado: EstadoPaso;
+  @IsOptional()
+  @IsEnum(EstadoPasoOrden)
+  estado?: EstadoPasoOrden
 }

--- a/src/paso-produccion/dto/update-paso-produccion.dto.ts
+++ b/src/paso-produccion/dto/update-paso-produccion.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString, IsNotEmpty, IsNumber, IsIn, IsUUID } from 'class-validator'
+import { IsOptional, IsString, IsNotEmpty, IsNumber, IsUUID, IsEnum } from 'class-validator'
+import { EstadoPasoOrden } from '../paso-produccion.entity'
 
 export class UpdatePasoProduccionDto {
   @IsOptional()
@@ -23,7 +24,6 @@ export class UpdatePasoProduccionDto {
   cantidadProducida?: number
 
   @IsOptional()
-  @IsString()
-  @IsIn(['pendiente', 'en_progreso', 'completado'])
-  estado?: string
+  @IsEnum(EstadoPasoOrden)
+  estado?: EstadoPasoOrden
 }

--- a/src/paso-produccion/paso-produccion.entity.ts
+++ b/src/paso-produccion/paso-produccion.entity.ts
@@ -9,6 +9,13 @@ import {
 } from 'typeorm';
 import { OrdenProduccion } from '../orden-produccion/entity';
 
+export enum EstadoPasoOrden {
+  PENDIENTE = 'pendiente',
+  ACTIVO = 'activo',
+  PAUSADO = 'pausado',
+  FINALIZADO = 'finalizado',
+}
+
 @Entity()
 export class PasoProduccion {
   @PrimaryGeneratedColumn('uuid')
@@ -30,8 +37,8 @@ export class PasoProduccion {
   @Column('int')
   cantidadProducida: number;
 
-  @Column({ type: 'enum', enum: ['pendiente', 'en_progreso', 'completado'] })
-  estado: 'pendiente' | 'en_progreso' | 'completado';
+  @Column({ type: 'enum', enum: EstadoPasoOrden, default: EstadoPasoOrden.PENDIENTE })
+  estado: EstadoPasoOrden;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/paso-produccion/paso-produccion.service.ts
+++ b/src/paso-produccion/paso-produccion.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
-import { PasoProduccion } from './paso-produccion.entity'
+import { PasoProduccion, EstadoPasoOrden } from './paso-produccion.entity'
+import { OrdenProduccion, EstadoOrdenProduccion } from '../orden-produccion/entity'
 import { CreatePasoProduccionDto } from './dto/create-paso-produccion.dto'
 import { UpdatePasoProduccionDto } from './dto/update-paso-produccion.dto'
 
@@ -30,11 +31,34 @@ export class PasoProduccionService {
   }
 
   async update(id: string, dto: UpdatePasoProduccionDto) {
-    const paso = await this.repo.findOne({ where: { id } });
+    const paso = await this.repo.findOne({ where: { id }, relations: ['orden'] });
     if (!paso) throw new NotFoundException('Paso no encontrado');
     if (dto.orden) paso.orden = { id: dto.orden } as any;
+    const estadoPrevio = paso.estado;
     Object.assign(paso, dto);
-    return this.repo.save(paso);
+    const saved = await this.repo.save(paso);
+
+    if (
+      dto.estado &&
+      dto.estado !== estadoPrevio &&
+      dto.estado === EstadoPasoOrden.FINALIZADO
+    ) {
+      const pasos = await this.repo.find({ where: { orden: { id: paso.orden.id } } });
+      const allFin = pasos.every((p) => p.estado === EstadoPasoOrden.FINALIZADO);
+      const anyPause = pasos.some((p) => p.estado === EstadoPasoOrden.PAUSADO);
+      const ordenRepo = this.repo.manager.getRepository(OrdenProduccion);
+      const orden = await ordenRepo.findOne({ where: { id: paso.orden.id } });
+      if (orden) {
+        if (allFin) {
+          orden.estado = EstadoOrdenProduccion.FINALIZADA;
+        } else if (anyPause) {
+          orden.estado = EstadoOrdenProduccion.PAUSADA;
+        }
+        await ordenRepo.save(orden);
+      }
+    }
+
+    return saved;
   }
 
   async remove(id: string) {

--- a/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
@@ -1,5 +1,4 @@
-import { IsUUID, IsNumber, IsOptional, IsIn } from 'class-validator';
-import { EstadoSesionTrabajoPaso } from '../sesion-trabajo-paso.entity';
+import { IsUUID, IsNumber, IsOptional } from 'class-validator';
 
 export class CreateSesionTrabajoPasoDto {
   @IsUUID()
@@ -15,7 +14,5 @@ export class CreateSesionTrabajoPasoDto {
   @IsNumber()
   cantidadProducida?: number;
 
-  @IsOptional()
-  @IsIn(['activo', 'pausado', 'finalizado'])
-  estado?: EstadoSesionTrabajoPaso;
+  // estado siempre inicia activo
 }

--- a/src/sesion-trabajo-paso/dto/update-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/update-sesion-trabajo-paso.dto.ts
@@ -1,4 +1,4 @@
-import { IsUUID, IsOptional, IsNumber, IsIn } from 'class-validator';
+import { IsUUID, IsOptional, IsNumber, IsEnum } from 'class-validator';
 import { EstadoSesionTrabajoPaso } from '../sesion-trabajo-paso.entity';
 
 export class UpdateSesionTrabajoPasoDto {
@@ -19,6 +19,6 @@ export class UpdateSesionTrabajoPasoDto {
   cantidadProducida?: number;
 
   @IsOptional()
-  @IsIn(['activo', 'pausado', 'finalizado'])
+  @IsEnum(EstadoSesionTrabajoPaso)
   estado?: EstadoSesionTrabajoPaso;
 }

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
@@ -37,7 +37,7 @@ export class SesionTrabajoPaso extends BaseEntity {
   @Column({
     type: 'enum',
     enum: EstadoSesionTrabajoPaso,
-    default: EstadoSesionTrabajoPaso.PAUSADO,
+    default: EstadoSesionTrabajoPaso.ACTIVO,
   })
   estado: EstadoSesionTrabajoPaso;
 }

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.module.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.module.ts
@@ -8,5 +8,6 @@ import { SesionTrabajoPasoController } from './sesion-trabajo-paso.controller';
   imports: [TypeOrmModule.forFeature([SesionTrabajoPaso])],
   providers: [SesionTrabajoPasoService],
   controllers: [SesionTrabajoPasoController],
+  exports: [SesionTrabajoPasoService],
 })
 export class SesionTrabajoPasoModule {}

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
@@ -5,6 +5,8 @@ import {
   SesionTrabajoPaso,
   EstadoSesionTrabajoPaso,
 } from './sesion-trabajo-paso.entity';
+import { PasoProduccion, EstadoPasoOrden } from '../paso-produccion/paso-produccion.entity';
+import { OrdenProduccion, EstadoOrdenProduccion } from '../orden-produccion/entity';
 import { CreateSesionTrabajoPasoDto } from './dto/create-sesion-trabajo-paso.dto';
 import { UpdateSesionTrabajoPasoDto } from './dto/update-sesion-trabajo-paso.dto';
 
@@ -15,15 +17,40 @@ export class SesionTrabajoPasoService {
     private readonly repo: Repository<SesionTrabajoPaso>,
   ) {}
 
-  create(dto: CreateSesionTrabajoPasoDto) {
+  async create(dto: CreateSesionTrabajoPasoDto) {
+    const activos = await this.repo.find({
+      where: { sesionTrabajo: { id: dto.sesionTrabajo }, estado: EstadoSesionTrabajoPaso.ACTIVO },
+    });
+    for (const a of activos) {
+      a.estado = EstadoSesionTrabajoPaso.PAUSADO;
+      await this.repo.save(a);
+    }
+
     const entity = this.repo.create({
       sesionTrabajo: { id: dto.sesionTrabajo } as any,
       pasoOrden: { id: dto.pasoOrden } as any,
       cantidadAsignada: dto.cantidadAsignada,
       cantidadProducida: dto.cantidadProducida ?? 0,
-      estado: dto.estado ?? EstadoSesionTrabajoPaso.PAUSADO,
+      estado: EstadoSesionTrabajoPaso.ACTIVO,
     });
-    return this.repo.save(entity);
+    const saved = await this.repo.save(entity);
+
+    const pasoRepo = this.repo.manager.getRepository(PasoProduccion);
+    const ordenRepo = this.repo.manager.getRepository(OrdenProduccion);
+    const paso = await pasoRepo.findOne({ where: { id: dto.pasoOrden }, relations: ['orden'] });
+    if (paso && paso.estado === EstadoPasoOrden.PENDIENTE) {
+      paso.estado = EstadoPasoOrden.ACTIVO;
+      await pasoRepo.save(paso);
+      const orden = await ordenRepo.findOne({ where: { id: paso.orden.id } });
+      if (orden && orden.estado === EstadoOrdenProduccion.PENDIENTE) {
+        orden.estado = EstadoOrdenProduccion.ACTIVA;
+        await ordenRepo.save(orden);
+      }
+    }
+
+    await this.verificarPaso(saved.pasoOrden.id);
+
+    return saved;
   }
 
   findAll() {
@@ -50,7 +77,15 @@ export class SesionTrabajoPasoService {
     if (dto.cantidadProducida !== undefined)
       entity.cantidadProducida = dto.cantidadProducida;
     if (dto.estado) entity.estado = dto.estado;
-    return this.repo.save(entity);
+    if (
+      entity.cantidadProducida >= entity.cantidadAsignada &&
+      entity.estado !== EstadoSesionTrabajoPaso.FINALIZADO
+    ) {
+      entity.estado = EstadoSesionTrabajoPaso.FINALIZADO;
+    }
+    const saved = await this.repo.save(entity);
+    await this.verificarPaso(saved.pasoOrden.id);
+    return saved;
   }
 
   async remove(id: string) {
@@ -87,5 +122,60 @@ export class SesionTrabajoPasoService {
     });
     await this.repo.remove(relaciones);
     return { deleted: true, count: relaciones.length };
+  }
+
+  private async verificarPaso(pasoId: string) {
+    const pasoRepo = this.repo.manager.getRepository(PasoProduccion);
+    const ordenRepo = this.repo.manager.getRepository(OrdenProduccion);
+    const paso = await pasoRepo.findOne({ where: { id: pasoId }, relations: ['orden'] });
+    if (!paso) return;
+    const relaciones = await this.repo.find({ where: { pasoOrden: { id: pasoId } } });
+    const total = relaciones.reduce((s, r) => s + r.cantidadProducida, 0);
+    const allFin = relaciones.every((r) => r.estado === EstadoSesionTrabajoPaso.FINALIZADO);
+    const anyActivo = relaciones.some((r) => r.estado === EstadoSesionTrabajoPaso.ACTIVO);
+    const allPausado =
+      relaciones.length > 0 &&
+      relaciones.every((r) => r.estado === EstadoSesionTrabajoPaso.PAUSADO);
+
+    let nuevoEstado = paso.estado;
+    if (allFin || total >= paso.cantidadRequerida) {
+      nuevoEstado = EstadoPasoOrden.FINALIZADO;
+    } else if (allPausado) {
+      nuevoEstado = EstadoPasoOrden.PAUSADO;
+    } else if (anyActivo) {
+      nuevoEstado = EstadoPasoOrden.ACTIVO;
+    }
+
+    if (nuevoEstado !== paso.estado) {
+      paso.estado = nuevoEstado;
+      await pasoRepo.save(paso);
+      await this.verificarOrden(paso.orden.id);
+    }
+  }
+
+  private async verificarOrden(ordenId: string) {
+    const ordenRepo = this.repo.manager.getRepository(OrdenProduccion);
+    const pasoRepo = this.repo.manager.getRepository(PasoProduccion);
+    const pasos = await pasoRepo.find({ where: { orden: { id: ordenId } } });
+    if (!pasos.length) return;
+    const allFin = pasos.every((p) => p.estado === EstadoPasoOrden.FINALIZADO);
+    const allPause = pasos.every((p) => p.estado === EstadoPasoOrden.PAUSADO);
+    const anyActivo = pasos.some((p) => p.estado === EstadoPasoOrden.ACTIVO);
+
+    const orden = await ordenRepo.findOne({ where: { id: ordenId } });
+    if (!orden) return;
+    let nuevo = orden.estado;
+    if (allFin) {
+      nuevo = EstadoOrdenProduccion.FINALIZADA;
+    } else if (allPause) {
+      nuevo = EstadoOrdenProduccion.PAUSADA;
+    } else if (anyActivo) {
+      nuevo = EstadoOrdenProduccion.ACTIVA;
+    }
+
+    if (nuevo !== orden.estado) {
+      orden.estado = nuevo;
+      await ordenRepo.save(orden);
+    }
   }
 }

--- a/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
+++ b/src/sesion-trabajo/dto/create-sesion-trabajo.dto.ts
@@ -1,5 +1,4 @@
-import { IsUUID, IsEnum, IsDateString, IsOptional } from 'class-validator';
-import { EstadoSesionTrabajo } from '../sesion-trabajo.entity';
+import { IsUUID, IsDateString, IsOptional } from 'class-validator';
 
 export class CreateSesionTrabajoDto {
   @IsUUID()
@@ -12,7 +11,4 @@ export class CreateSesionTrabajoDto {
   @IsDateString()
   fechaFin?: Date;
 
-  @IsOptional()
-  @IsEnum(EstadoSesionTrabajo)
-  estado?: EstadoSesionTrabajo;
 }

--- a/src/sesion-trabajo/sesion-trabajo.controller.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Param, Body, Put, Delete } from '@nestjs/common';
+import { Controller, Post, Get, Param, Body, Put, Delete, Patch } from '@nestjs/common';
 import { SesionTrabajoService } from './sesion-trabajo.service';
 import { CreateSesionTrabajoDto } from './dto/create-sesion-trabajo.dto';
 import { UpdateSesionTrabajoDto } from './dto/update-sesion-trabajo.dto';
@@ -30,6 +30,16 @@ export class SesionTrabajoController {
   @Put(':id')
   update(@Param('id') id: string, @Body() dto: UpdateSesionTrabajoDto) {
     return this.service.update(id, dto);
+  }
+
+  @Patch(':id/finalizar')
+  finalizar(@Param('id') id: string) {
+    return this.service.finalizar(id);
+  }
+
+  @Patch(':id/pausar')
+  pausar(@Param('id') id: string) {
+    return this.service.pausar(id);
   }
 
   @Delete(':id')

--- a/src/sesion-trabajo/sesion-trabajo.entity.ts
+++ b/src/sesion-trabajo/sesion-trabajo.entity.ts
@@ -4,6 +4,7 @@ import { Maquina } from '../maquina/maquina.entity';
 
 export enum EstadoSesionTrabajo {
   ACTIVA = 'activa',
+  PAUSADA = 'pausada',
   FINALIZADA = 'finalizada',
 }
 

--- a/src/sesion-trabajo/sesion-trabajo.module.ts
+++ b/src/sesion-trabajo/sesion-trabajo.module.ts
@@ -5,12 +5,14 @@ import { SesionTrabajoService } from './sesion-trabajo.service';
 import { SesionTrabajoController } from './sesion-trabajo.controller';
 import { RegistroMinutoModule } from '../registro-minuto/registro-minuto.module';
 import { EstadoSesionModule } from '../estado-sesion/estado-sesion.module';
+import { SesionTrabajoPasoModule } from '../sesion-trabajo-paso/sesion-trabajo-paso.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([SesionTrabajo]),
     RegistroMinutoModule,
     EstadoSesionModule,
+    SesionTrabajoPasoModule,
   ],
   providers: [SesionTrabajoService],
   controllers: [SesionTrabajoController],

--- a/src/sesion-trabajo/sesion-trabajo.service.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.ts
@@ -1,13 +1,18 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { SesionTrabajo, EstadoSesionTrabajo } from './sesion-trabajo.entity';
+import {
+  SesionTrabajo,
+  EstadoSesionTrabajo,
+} from './sesion-trabajo.entity';
 import { CreateSesionTrabajoDto } from './dto/create-sesion-trabajo.dto';
 import { UpdateSesionTrabajoDto } from './dto/update-sesion-trabajo.dto';
 import { RegistroMinutoService } from '../registro-minuto/registro-minuto.service';
 import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
 import { ConfiguracionService } from '../configuracion/configuracion.service';
 import { DateTime } from 'luxon';
+import { EstadoSesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
+import { SesionTrabajoPasoService } from '../sesion-trabajo-paso/sesion-trabajo-paso.service';
 
 @Injectable()
 export class SesionTrabajoService {
@@ -17,20 +22,19 @@ export class SesionTrabajoService {
     private readonly registroMinutoService: RegistroMinutoService,
     private readonly estadoSesionService: EstadoSesionService,
     private readonly configService: ConfiguracionService,
+    private readonly stpService: SesionTrabajoPasoService,
   ) {}
 
   async create(dto: CreateSesionTrabajoDto) {
     await this.finalizarSesionesPrevias(dto.trabajador);
     const sesion = this.repo.create({
-      ...dto,
-      fechaInicio: DateTime.now().setZone('America/Bogota').toJSDate(),
-      fechaFin: dto.fechaFin
-
-        ? DateTime.fromJSDate(dto.fechaFin, { zone: 'America/Bogota' }).toJSDate()
-
-        : undefined,
       trabajador: { id: dto.trabajador } as any,
       maquina: { id: dto.maquina } as any,
+      fechaInicio: DateTime.now().setZone('America/Bogota').toJSDate(),
+      fechaFin: dto.fechaFin
+        ? DateTime.fromJSDate(dto.fechaFin, { zone: 'America/Bogota' }).toJSDate()
+        : undefined,
+      estado: EstadoSesionTrabajo.ACTIVA,
     });
     return this.repo.save(sesion);
   }
@@ -62,8 +66,49 @@ export class SesionTrabajoService {
     if (dto.fechaFin)
       sesion.fechaFin = DateTime.fromJSDate(dto.fechaFin, { zone: 'America/Bogota' }).toJSDate();
 
+    if (dto.estado === EstadoSesionTrabajo.FINALIZADA) {
+      return this.finalizar(id);
+    }
+    if (dto.estado === EstadoSesionTrabajo.PAUSADA) {
+      return this.pausar(id);
+    }
+
     Object.assign(sesion, dto);
     return this.repo.save(sesion);
+  }
+
+  async finalizar(id: string) {
+    const sesion = await this.repo.findOne({ where: { id } });
+    if (!sesion) throw new NotFoundException('Sesión no encontrada');
+    sesion.estado = EstadoSesionTrabajo.FINALIZADA;
+    sesion.fechaFin = DateTime.now().setZone('America/Bogota').toJSDate();
+    await this.repo.save(sesion);
+    const pasos = await this.repo.manager
+      .getRepository('sesion_trabajo_paso')
+      .find({ where: { sesionTrabajo: { id } } });
+    for (const p of pasos) {
+      await this.stpService.update(p.id, {
+        estado: EstadoSesionTrabajoPaso.FINALIZADO,
+      });
+    }
+    return sesion;
+  }
+
+  async pausar(id: string) {
+    const sesion = await this.repo.findOne({ where: { id } });
+    if (!sesion) throw new NotFoundException('Sesión no encontrada');
+    sesion.estado = EstadoSesionTrabajo.PAUSADA;
+    await this.repo.save(sesion);
+    const repoPaso = this.repo.manager.getRepository('sesion_trabajo_paso');
+    const pasos = await repoPaso.find({ where: { sesionTrabajo: { id } } });
+    for (const p of pasos) {
+      if (p.estado !== EstadoSesionTrabajoPaso.FINALIZADO) {
+        await this.stpService.update(p.id, {
+          estado: EstadoSesionTrabajoPaso.PAUSADO,
+        });
+      }
+    }
+    return sesion;
   }
 
   async remove(id: string) {


### PR DESCRIPTION
## Summary
- expand session states with `PAUSADA`
- pause or finalize session steps when sessions change state
- activate order and step on first step-session creation
- finalize order when its steps all finalize
- ensure state enums propagate properly

## Testing
- `npm run build`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68895725ea2483259ea4af0aaa953784