### PR TITLE
Fix orden produccion types

### DIFF
--- a/src/orden-produccion/dto/crear-orden.dto.ts
+++ b/src/orden-produccion/dto/crear-orden.dto.ts
@@ -4,9 +4,11 @@ import {
   IsDate,
   ValidateNested,
   IsArray,
+  IsEnum,
 } from 'class-validator'
 import { Type } from 'class-transformer'
 import { PasoOrdenDto } from './paso-orden.dto'
+import { EstadoOrdenProduccion } from '../entity'
 
 export class CrearOrdenDto {
   @IsString()
@@ -26,8 +28,8 @@ export class CrearOrdenDto {
   @IsDate()
   fechaVencimiento: Date
 
-  @IsString()
-  estado: string
+  @IsEnum(EstadoOrdenProduccion)
+  estado: EstadoOrdenProduccion
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/orden-produccion/dto/paso-orden.dto.ts
+++ b/src/orden-produccion/dto/paso-orden.dto.ts
@@ -1,5 +1,11 @@
-import { IsString, IsNotEmpty, IsNumber, IsIn, IsOptional } from 'class-validator';
-import { EstadoPaso } from '../../paso-produccion/dto/create-paso-produccion.dto';
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsEnum,
+} from 'class-validator';
+import { EstadoPasoOrden } from '../../paso-produccion/paso-produccion.entity';
 
 export class PasoOrdenDto {
   @IsString()
@@ -17,7 +23,6 @@ export class PasoOrdenDto {
   cantidadProducida?: number;
 
   @IsOptional()
-  @IsString()
-  @IsIn(['pendiente', 'en_progreso', 'completado'])
-  estado?: EstadoPaso;
+  @IsEnum(EstadoPasoOrden)
+  estado?: EstadoPasoOrden;
 }

--- a/src/orden-produccion/orden-produccion.service.ts
+++ b/src/orden-produccion/orden-produccion.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
-import { OrdenProduccion } from './entity'
+import { OrdenProduccion, EstadoOrdenProduccion } from './entity'
 import { CrearOrdenDto } from './dto/crear-orden.dto'
 import { ActualizarOrdenDto } from './dto/actualizar-orden.dto'
 import { PasoOrdenDto } from './dto/paso-orden.dto'
-import { PasoProduccion } from '../paso-produccion/paso-produccion.entity'
+import { PasoProduccion, EstadoPasoOrden } from '../paso-produccion/paso-produccion.entity'
 import {
   SesionTrabajo,
   EstadoSesionTrabajo,
@@ -46,7 +46,7 @@ export class OrdenProduccionService {
         const paso = this.pasoRepo.create({
           ...pasoDto,
           cantidadProducida: pasoDto.cantidadProducida ?? 0,
-          estado: (pasoDto.estado as any) ?? 'pendiente',
+          estado: pasoDto.estado ?? EstadoPasoOrden.PENDIENTE,
           orden,
         });
         await this.pasoRepo.save(paso);
@@ -102,7 +102,7 @@ export class OrdenProduccionService {
         const paso = this.pasoRepo.create({
           ...pasoDto,
           cantidadProducida: pasoDto.cantidadProducida ?? 0,
-          estado: (pasoDto.estado as any) ?? 'pendiente',
+          estado: pasoDto.estado ?? EstadoPasoOrden.PENDIENTE,
           orden,
         });
         const pasoGuardado = await this.pasoRepo.save(paso);


### PR DESCRIPTION
## Summary
- fix PasoOrdenDto to use `EstadoPasoOrden` enum
- update order creation DTO to validate `EstadoOrdenProduccion`
- adjust service to use proper enum values

## Testing
- `npx tsc -p tsconfig.build.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688973555b44832594d7f48e99ef21ac