### PR TITLE
Add machine name to session-work-step entity

### DIFF
--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.entity.ts
@@ -40,6 +40,9 @@ export class SesionTrabajoPaso extends BaseEntity {
   @Column({ default: 'Desconocido' })
   nombreTrabajador: string;
 
+  @Column({ default: 'Desconocido' })
+  nombreMaquina: string;
+
   @Column({
     type: 'enum',
     enum: EstadoSesionTrabajoPaso,

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
@@ -48,10 +48,11 @@ export class SesionTrabajoPasoService {
     const sesionRepo = this.repo.manager.getRepository(SesionTrabajo);
     const sesion = await sesionRepo.findOne({
       where: { id: dto.sesionTrabajo },
-      relations: ['trabajador'],
+      relations: ['trabajador', 'maquina'],
     });
     if (sesion) {
       entity.nombreTrabajador = sesion.trabajador?.nombre ?? '';
+      entity.nombreMaquina = sesion.maquina?.nombre ?? '';
     }
 
     const saved = await this.repo.save(entity);
@@ -96,10 +97,11 @@ export class SesionTrabajoPasoService {
       const sesionRepo = this.repo.manager.getRepository(SesionTrabajo);
       const sesion = await sesionRepo.findOne({
         where: { id: dto.sesionTrabajo },
-        relations: ['trabajador'],
+        relations: ['trabajador', 'maquina'],
       });
       if (sesion) {
         entity.nombreTrabajador = sesion.trabajador?.nombre ?? '';
+        entity.nombreMaquina = sesion.maquina?.nombre ?? '';
       }
     }
     if (dto.pasoOrden) entity.pasoOrden = { id: dto.pasoOrden } as any;


### PR DESCRIPTION
## Summary
- store machine name when creating/updating a session-work-step
- add `nombreMaquina` column to `SesionTrabajoPaso`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a43726a90832584e50e559654cbbc