### PR TITLE
Allow optional estado when creating sesion-trabajo-paso

### DIFF
--- a/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
@@ -1,4 +1,5 @@
-import { IsUUID, IsNumber, IsOptional } from 'class-validator';
+import { IsUUID, IsNumber, IsOptional, IsEnum } from 'class-validator';
+import { EstadoSesionTrabajoPaso } from '../sesion-trabajo-paso.entity';
 
 export class CreateSesionTrabajoPasoDto {
   @IsUUID()
@@ -18,5 +19,7 @@ export class CreateSesionTrabajoPasoDto {
   @IsNumber()
   cantidadPedaleos?: number;
 
-  // estado siempre inicia activo
+  @IsOptional()
+  @IsEnum(EstadoSesionTrabajoPaso)
+  estado?: EstadoSesionTrabajoPaso;
 }

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
@@ -42,7 +42,7 @@ export class SesionTrabajoPasoService {
       cantidadAsignada: dto.cantidadAsignada,
       cantidadProducida: dto.cantidadProducida ?? 0,
       cantidadPedaleos: dto.cantidadPedaleos ?? 0,
-      estado: EstadoSesionTrabajoPaso.ACTIVO,
+      estado: dto.estado ?? EstadoSesionTrabajoPaso.ACTIVO,
     });
 
     const sesionRepo = this.repo.manager.getRepository(SesionTrabajo);


### PR DESCRIPTION
## Summary
- add `estado` field to `CreateSesionTrabajoPasoDto`
- use provided `estado` value during creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a76e566748325951c57656eadea20