### PR TITLE
Fix counts propagation when saving records

### DIFF
--- a/src/registro-minuto/registro-minuto.service.ts
+++ b/src/registro-minuto/registro-minuto.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { RegistroMinuto } from './registro-minuto.entity';
 import {
   SesionTrabajoPaso,
@@ -108,11 +108,19 @@ export class RegistroMinutoService {
           const activo = await this.stpRepo.findOne({
             where: {
               sesionTrabajo: { id: sesionTrabajoId },
-              estado: EstadoSesionTrabajoPaso.ACTIVO,
+              estado: In([
+                EstadoSesionTrabajoPaso.ACTIVO,
+                EstadoSesionTrabajoPaso.PENDIENTE,
+              ]),
             },
             relations: ['pasoOrden'],
           });
+
           if (activo) {
+            if (activo.estado === EstadoSesionTrabajoPaso.PENDIENTE) {
+              activo.estado = EstadoSesionTrabajoPaso.ACTIVO;
+            }
+
             activo.cantidadProducida += dto.piezasContadas;
             activo.cantidadPedaleos += dto.pedaleadas;
             await this.stpRepo.save(activo);


### PR DESCRIPTION
## Summary
- update registro-minuto service to find any active or pending assignment when updating counts
- set pending assignments to active when first data is saved

## Testing
- `npm test`
- `npm run lint` *(fails: 34 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688a81a5d35483259605cc6ad56aafbd