### PR TITLE
Add efficient endpoint to list active sessions

### DIFF
--- a/src/sesion-trabajo/sesion-trabajo.controller.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SesionTrabajoController } from './sesion-trabajo.controller';
+import { SesionTrabajoService } from './sesion-trabajo.service';
+
+describe('SesionTrabajoController', () => {
+  let controller: SesionTrabajoController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SesionTrabajoController],
+      providers: [{ provide: SesionTrabajoService, useValue: {} }],
+    }).compile();
+
+    controller = module.get<SesionTrabajoController>(SesionTrabajoController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/sesion-trabajo/sesion-trabajo.controller.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.ts
@@ -27,6 +27,11 @@ export class SesionTrabajoController {
     return this.service.findActivas();
   }
 
+  @Get('activas/resumen')
+  findActivasResumen() {
+    return this.service.findActivasResumen();
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.service.findOne(id);

--- a/src/sesion-trabajo/sesion-trabajo.service.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SesionTrabajoService } from './sesion-trabajo.service';
+import { SesionTrabajo } from './sesion-trabajo.entity';
+import { RegistroMinutoService } from '../registro-minuto/registro-minuto.service';
+import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
+import { ConfiguracionService } from '../configuracion/configuracion.service';
+
+describe('SesionTrabajoService', () => {
+  let service: SesionTrabajoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SesionTrabajoService,
+        { provide: getRepositoryToken(SesionTrabajo), useClass: Repository },
+        { provide: RegistroMinutoService, useValue: {} },
+        { provide: EstadoSesionService, useValue: {} },
+        { provide: ConfiguracionService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<SesionTrabajoService>(SesionTrabajoService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/sesion-trabajo/sesion-trabajo.service.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.ts
@@ -241,6 +241,18 @@ export class SesionTrabajoService {
     });
   }
 
+  async findActivasResumen() {
+    return this.repo
+      .createQueryBuilder('s')
+      .leftJoin('s.trabajador', 't')
+      .leftJoin('s.maquina', 'm')
+      .select(['s.id', 's.fechaInicio'])
+      .addSelect(['t.id', 't.nombre'])
+      .addSelect(['m.id', 'm.nombre'])
+      .where('s.estado = :estado', { estado: EstadoSesionTrabajo.ACTIVA })
+      .getMany();
+  }
+
   private async finalizarSesionesPrevias(trabajadorId: string) {
     const activas = await this.repo.find({
       where: {


### PR DESCRIPTION
## Summary
- implement `findActivasResumen` using a query builder
- expose `/sesiones-trabajo/activas/resumen` endpoint
- add basic unit tests for SesionTrabajo service and controller

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b72ccff408325bd0f0add8894c83c