### PR TITLE
Add codigo to Maquina with uniqueness check

### DIFF
--- a/src/maquina/dto/create-maquina.dto.ts
+++ b/src/maquina/dto/create-maquina.dto.ts
@@ -18,6 +18,10 @@ export class CreateMaquinaDto {
   @Length(1, 50)
   nombre: string
 
+  @IsString()
+  @Length(1, 50)
+  codigo: string
+
   @IsEnum(EstadoMaquina)
   estado: EstadoMaquina
 

--- a/src/maquina/maquina.entity.ts
+++ b/src/maquina/maquina.entity.ts
@@ -20,6 +20,9 @@ export class Maquina {
   @Column()
   nombre: string;
 
+  @Column({ default: '' })
+  codigo: string;
+
   @Column({ length: 100, nullable: true })
   ubicacion: string;
 

--- a/src/maquina/maquina.service.ts
+++ b/src/maquina/maquina.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { CreateMaquinaDto } from './dto/create-maquina.dto';
 import { UpdateEstadoDto } from './dto/update-estado.dto';
 import { UpdateMaquinaDto } from './dto/update-maquina.dto';
@@ -11,6 +11,9 @@ export class MaquinaService {
   constructor(@InjectRepository(Maquina) private readonly repo: Repository<Maquina>) {}
 
   async create(dto: CreateMaquinaDto) {
+    const existente = await this.repo.findOne({ where: { codigo: dto.codigo } });
+    if (existente)
+      throw new BadRequestException('No se puede repetir el codigo de equipo');
     const nueva = this.repo.create(dto);
     return this.repo.save(nueva);
   }


### PR DESCRIPTION
## Summary
- add `codigo` field to `Maquina` entity
- include `codigo` in machine creation DTO
- validate unique machine `codigo` when creating a machine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bab0921c48325a1991b45d7872c0d