### PR TITLE
Delay paso finalization

### DIFF
--- a/src/paso-produccion/paso-produccion.entity.ts
+++ b/src/paso-produccion/paso-produccion.entity.ts
@@ -40,6 +40,9 @@ export class PasoProduccion {
   @Column('int', { default: 0 })
   cantidadPedaleos: number;
 
+  @Column({ type: 'timestamptz', nullable: true })
+  fechaMetaAlcanzada: Date | null;
+
   @Column({ type: 'enum', enum: EstadoPasoOrden, default: EstadoPasoOrden.PENDIENTE })
   estado: EstadoPasoOrden;
 


### PR DESCRIPTION
## Summary
- add fechaMetaAlcanzada column to track when target pedaleos achieved
- finalize pasos 5 minutes after reaching pedaleos goal
- auto-finalize pending pasos on cron run

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bd86a222483259834db81816340f0