### PR TITLE
refactor: update session state model

### DIFF
--- a/src/estado-sesion/dto/create-estado-sesion.dto.ts
+++ b/src/estado-sesion/dto/create-estado-sesion.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsUUID, IsDate } from 'class-validator';
+import { IsEnum, IsUUID, IsDate, IsOptional } from 'class-validator';
 import { Type } from 'class-transformer';
 import { TipoEstadoSesion } from '../estado-sesion.entity';
 
@@ -12,4 +12,9 @@ export class CreateEstadoSesionDto {
   @Type(() => Date)
   @IsDate()
   inicio: Date;
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  fin?: Date;
 }

--- a/src/estado-sesion/dto/update-estado-sesion.dto.ts
+++ b/src/estado-sesion/dto/update-estado-sesion.dto.ts
@@ -13,4 +13,8 @@ export class UpdateEstadoSesionDto {
   @IsOptional()
   @IsDate()
   inicio?: Date;
+
+  @IsOptional()
+  @IsDate()
+  fin?: Date;
 }

--- a/src/estado-sesion/estado-sesion.entity.ts
+++ b/src/estado-sesion/estado-sesion.entity.ts
@@ -2,9 +2,9 @@ import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEnti
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
 
 export enum TipoEstadoSesion {
-  DESCANSO = 'descanso',
-  MANTENIMIENTO = 'mantenimiento',
   PRODUCCION = 'produccion',
+  INACTIVO = 'inactivo',
+  OTRO = 'otro',
 }
 
 @Entity('estado_sesion')
@@ -21,4 +21,7 @@ export class EstadoSesion extends BaseEntity {
 
   @Column({ type: 'timestamp' })
   inicio: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  fin: Date | null;
 }

--- a/src/estado-sesion/estado-sesion.service.ts
+++ b/src/estado-sesion/estado-sesion.service.ts
@@ -16,9 +16,10 @@ export class EstadoSesionService {
   async create(dto: CreateEstadoSesionDto) {
     const nuevo = this.repo.create({
       ...dto,
-
       inicio: DateTime.fromJSDate(dto.inicio, { zone: 'America/Bogota' }).toJSDate(),
-
+      fin: dto.fin
+        ? DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate()
+        : null,
       sesionTrabajo: { id: dto.sesionTrabajo } as any,
     });
     return this.repo.save(nuevo);
@@ -44,9 +45,9 @@ export class EstadoSesionService {
     if (dto.sesionTrabajo)
       estado.sesionTrabajo = { id: dto.sesionTrabajo } as any;
     if (dto.inicio)
-
       estado.inicio = DateTime.fromJSDate(dto.inicio, { zone: 'America/Bogota' }).toJSDate();
-
+    if (dto.fin)
+      estado.fin = DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate();
     Object.assign(estado, dto);
     return this.repo.save(estado);
   }


### PR DESCRIPTION
## Summary
- refactor session state enum to {produccion, inactivo, otro}
- track optional end time in session state records
- support end time in creation and update DTOs and service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689235972c948325a9b69d7687731be9