### PR TITLE
refactor: remove estado attributes from worker and machine

### DIFF
--- a/src/maquina/dto/create-maquina.dto.ts
+++ b/src/maquina/dto/create-maquina.dto.ts
@@ -1,10 +1,5 @@
 import { IsString, Length, IsISO8601, IsEnum } from 'class-validator'
 
-export enum EstadoMaquina {
-  ACTIVA = 'activa',
-  NO_ACTIVA = 'no activa'
-}
-
 export enum TipoMaquina {
   TROQUELADORA = 'troqueladora',
   TALADRO = 'taladro',
@@ -21,9 +16,6 @@ export class CreateMaquinaDto {
   @IsString()
   @Length(1, 50)
   codigo: string
-
-  @IsEnum(EstadoMaquina)
-  estado: EstadoMaquina
 
   @IsString()
   @Length(1, 100)

--- a/src/maquina/dto/index.ts
+++ b/src/maquina/dto/index.ts
@@ -1,3 +1,2 @@
 export * from './create-maquina.dto';
-export * from './update-estado.dto';
 export * from './update-maquina.dto';

--- a/src/maquina/dto/update-estado.dto.ts
+++ b/src/maquina/dto/update-estado.dto.ts
@@ -1,7 +1,0 @@
-import { IsString, IsIn } from 'class-validator'
-
-export class UpdateEstadoDto {
-  @IsString()
-  @IsIn(['activo', 'inactivo', 'mantenimiento'])
-  estado: string
-}

--- a/src/maquina/dto/update-maquina.dto.ts
+++ b/src/maquina/dto/update-maquina.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, Length, IsISO8601, IsEnum, IsOptional } from 'class-validator'
-import { EstadoMaquina, TipoMaquina } from './create-maquina.dto'
+import { TipoMaquina } from './create-maquina.dto'
 
 export class UpdateMaquinaDto {
 
@@ -7,10 +7,6 @@ export class UpdateMaquinaDto {
   @IsString()
   @Length(1, 50)
   nombre?: string
-
-  @IsOptional()
-  @IsEnum(EstadoMaquina)
-  estado?: EstadoMaquina
 
   @IsOptional()
   @IsString()

--- a/src/maquina/maquina.controller.ts
+++ b/src/maquina/maquina.controller.ts
@@ -1,7 +1,6 @@
-import { Controller, Post, Get, Put,Patch, Param, Body, Delete } from '@nestjs/common';
+import { Controller, Post, Get, Put, Param, Body, Delete } from '@nestjs/common';
 import { MaquinaService } from './maquina.service';
 import { CreateMaquinaDto } from './dto/create-maquina.dto';
-import { UpdateEstadoDto } from './dto/update-estado.dto';
 import { UpdateMaquinaDto } from './dto/update-maquina.dto';
 
 @Controller('maquinas')
@@ -21,11 +20,6 @@ export class MaquinaController {
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.maquinaService.findOne(id);
-  }
-
-  @Patch(':id/estado')
-  updateEstado(@Param('id') id: string, @Body() dto: UpdateEstadoDto) {
-    return this.maquinaService.updateEstado(id, dto);
   }
 
   @Put(':id')

--- a/src/maquina/maquina.entity.ts
+++ b/src/maquina/maquina.entity.ts
@@ -1,8 +1,3 @@
-export enum EstadoMaquina {
-  ACTIVA = 'activa',
-  NO_ACTIVA = 'no activa'
-}
-
 export enum TipoMaquina {
   TROQUELADORA = 'troqueladora',
   TALADRO = 'taladro',
@@ -31,9 +26,6 @@ export class Maquina {
 
   @Column({ type: 'enum', enum: TipoMaquina, nullable: true })
   tipo: TipoMaquina;
-
-  @Column({ type: 'enum', enum: EstadoMaquina, default: EstadoMaquina.ACTIVA })
-  estado: EstadoMaquina;
 
   @Column({ length: 255, nullable: true })
   observaciones: string;

--- a/src/maquina/maquina.service.ts
+++ b/src/maquina/maquina.service.ts
@@ -1,10 +1,9 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { CreateMaquinaDto } from './dto/create-maquina.dto';
-import { UpdateEstadoDto } from './dto/update-estado.dto';
 import { UpdateMaquinaDto } from './dto/update-maquina.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Maquina, EstadoMaquina } from './maquina.entity';
+import { Maquina } from './maquina.entity';
 
 @Injectable()
 export class MaquinaService {
@@ -26,13 +25,6 @@ export class MaquinaService {
     const maquina = await this.repo.findOne({ where: { id } });
     if (!maquina) throw new NotFoundException('Máquina no encontrada');
     return maquina;
-  }
-
-  async updateEstado(id: string, dto: UpdateEstadoDto) {
-    const maquina = await this.repo.findOne({ where: { id } });
-    if (!maquina) throw new NotFoundException('Máquina no encontrada');
-    maquina.estado = dto.estado as EstadoMaquina;
-    return this.repo.save(maquina);
   }
 
   async update(id: string, dto: UpdateMaquinaDto) {

--- a/src/trabajador/dto/create-trabajador.dto.ts
+++ b/src/trabajador/dto/create-trabajador.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsNotEmpty, IsIn, IsISO8601 } from 'class-validator';
-import { EstadoTrabajador, GrupoTrabajador, TurnoTrabajador } from './update-trabajador.dto';
+import { GrupoTrabajador, TurnoTrabajador } from './update-trabajador.dto';
 
 export class CreateTrabajadorDto {
   @IsString()
@@ -15,15 +15,6 @@ export class CreateTrabajadorDto {
 
   @IsIn([TurnoTrabajador.MANANA, TurnoTrabajador.TARDE, TurnoTrabajador.NOCHE])
   turno: TurnoTrabajador;
-
-  @IsIn([
-    EstadoTrabajador.CREADO,
-    EstadoTrabajador.EN_PRODUCCION,
-    EstadoTrabajador.EN_DESCANSO,
-    EstadoTrabajador.FUERA_DE_TURNO,
-    EstadoTrabajador.INACTIVO_EN_TURNO,
-  ])
-  estado: EstadoTrabajador;
 
   @IsISO8601()
   fechaInicio: string;

--- a/src/trabajador/dto/update-trabajador.dto.ts
+++ b/src/trabajador/dto/update-trabajador.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsBoolean, IsIn, IsISO8601 } from 'class-validator';
+import { IsOptional, IsString, IsIn, IsISO8601 } from 'class-validator';
 
 export enum GrupoTrabajador {
   PRODUCCION = 'produccion',
@@ -9,14 +9,6 @@ export enum TurnoTrabajador {
   MANANA = 'mañana',
   TARDE = 'tarde',
   NOCHE = 'noche'
-}
-
-export enum EstadoTrabajador {
-  CREADO = 'creado',
-  EN_PRODUCCION = 'en produccion',
-  EN_DESCANSO = 'en descanso',
-  FUERA_DE_TURNO = 'fuera de turno',
-  INACTIVO_EN_TURNO = 'inactivo en turno'
 }
 
 export class UpdateTrabajadorDto {
@@ -40,13 +32,4 @@ export class UpdateTrabajadorDto {
   @IsISO8601()
   fechaInicio?: string;
 
-  @IsOptional()
-  @IsIn([
-    EstadoTrabajador.CREADO,
-    EstadoTrabajador.EN_PRODUCCION,
-    EstadoTrabajador.EN_DESCANSO,
-    EstadoTrabajador.FUERA_DE_TURNO,
-    EstadoTrabajador.INACTIVO_EN_TURNO,
-  ])
-  estado?: EstadoTrabajador;
 }

--- a/src/trabajador/trabajador.controller.ts
+++ b/src/trabajador/trabajador.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Put, Patch, Param, Body, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Put, Param, Body, Delete } from '@nestjs/common';
 import { TrabajadorService } from './trabajador.service';
 import { CreateTrabajadorDto } from './dto/create-trabajador.dto';
-import { UpdateTrabajadorDto, EstadoTrabajador } from './dto/update-trabajador.dto';
+import { UpdateTrabajadorDto } from './dto/update-trabajador.dto';
 
 @Controller('trabajadores')
 export class TrabajadorController {
@@ -29,12 +29,6 @@ export class TrabajadorController {
   @Put(':id')
   actualizar(@Param('id') id: string, @Body() body: UpdateTrabajadorDto) {
     return this.service.actualizar(id, body);
-  }
-
-  // Cambia el estado (activo/inactivo) de un trabajador por su ID
-  @Patch(':id/estado')
-  cambiarEstado(@Param('id') id: string, @Body('estado') estado: EstadoTrabajador) {
-    return this.service.cambiarEstado(id, estado);
   }
 
   @Delete(':id')

--- a/src/trabajador/trabajador.entity.ts
+++ b/src/trabajador/trabajador.entity.ts
@@ -1,5 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, BaseEntity } from 'typeorm'
-import { EstadoTrabajador, GrupoTrabajador, TurnoTrabajador } from '../trabajador/dto/update-trabajador.dto'
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  BaseEntity,
+} from 'typeorm'
+import { GrupoTrabajador, TurnoTrabajador } from './dto/update-trabajador.dto'
 
 @Entity('trabajador')
 export class Trabajador extends BaseEntity {
@@ -11,9 +18,6 @@ export class Trabajador extends BaseEntity {
 
   @Column({ unique: true })
   identificacion: string
-
-  @Column({ type: 'enum', enum: EstadoTrabajador, default: EstadoTrabajador.CREADO })
-  estado: EstadoTrabajador
 
   @Column({ type: 'enum', enum: GrupoTrabajador })
   grupo: GrupoTrabajador

--- a/src/trabajador/trabajador.service.ts
+++ b/src/trabajador/trabajador.service.ts
@@ -1,4 +1,3 @@
-import { EstadoTrabajador } from './dto/update-trabajador.dto'
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
@@ -54,13 +53,6 @@ export class TrabajadorService {
     return { mensaje: `Trabajador ${id} actualizado`, data: trabajador }
   }
 
-  async cambiarEstado(id: string, estado: EstadoTrabajador) {
-    const trabajador = await this.repo.findOneBy({ id })
-    if (!trabajador) throw new NotFoundException('Trabajador no encontrado')
-    trabajador.estado = estado
-    await this.repo.save(trabajador)
-    return { mensaje: `Estado de trabajador ${id} cambiado a ${estado}` }
-  }
   async eliminar(id: string) {
     const trabajador = await this.repo.findOneBy({ id })
     if (!trabajador) throw new NotFoundException('Trabajador no encontrado')


### PR DESCRIPTION
## Summary
- remove obsolete `estado` columns from `Trabajador` and `Maquina`
- drop state handling endpoints and DTO fields accordingly
- simplify services and controllers to work without direct state fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923cb71f9483259b42e0a6f07c66a3