### PR TITLE
feat: manage session state for worker and machine statuses

### DIFF
--- a/src/estado-maquina/estado-maquina.module.ts
+++ b/src/estado-maquina/estado-maquina.module.ts
@@ -3,9 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EstadoMaquina } from './estado-maquina.entity';
 import { EstadoMaquinaService } from './estado-maquina.service';
 import { EstadoMaquinaController } from './estado-maquina.controller';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
+import { EstadoSesionModule } from '../estado-sesion/estado-sesion.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([EstadoMaquina])],
+  imports: [
+    TypeOrmModule.forFeature([EstadoMaquina, SesionTrabajo, EstadoTrabajador]),
+    EstadoSesionModule,
+  ],
   controllers: [EstadoMaquinaController],
   providers: [EstadoMaquinaService],
   exports: [EstadoMaquinaService],

--- a/src/estado-maquina/estado-maquina.service.ts
+++ b/src/estado-maquina/estado-maquina.service.ts
@@ -1,28 +1,54 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, IsNull } from 'typeorm';
 import { DateTime } from 'luxon';
 import { EstadoMaquina } from './estado-maquina.entity';
 import { CreateEstadoMaquinaDto } from './dto/create-estado-maquina.dto';
 import { UpdateEstadoMaquinaDto } from './dto/update-estado-maquina.dto';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
+import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
+import { TipoEstadoSesion } from '../estado-sesion/estado-sesion.entity';
 
 @Injectable()
 export class EstadoMaquinaService {
   constructor(
     @InjectRepository(EstadoMaquina)
     private readonly repo: Repository<EstadoMaquina>,
+    @InjectRepository(SesionTrabajo)
+    private readonly sesionRepo: Repository<SesionTrabajo>,
+    @InjectRepository(EstadoTrabajador)
+    private readonly estadoTrabajadorRepo: Repository<EstadoTrabajador>,
+    private readonly estadoSesionService: EstadoSesionService,
   ) {}
 
   async create(dto: CreateEstadoMaquinaDto) {
+    const inicio = DateTime.fromJSDate(dto.inicio, {
+      zone: 'America/Bogota',
+    }).toJSDate();
+    const fin = dto.fin
+      ? DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate()
+      : null;
+
+    const abiertos = await this.repo.find({
+      where: { maquina: { id: dto.maquina }, fin: IsNull() },
+    });
+    for (const a of abiertos) {
+      a.fin = inicio;
+      await this.repo.save(a);
+    }
+
     const entity = this.repo.create({
       maquina: { id: dto.maquina } as any,
       mantenimiento: dto.mantenimiento,
-      inicio: DateTime.fromJSDate(dto.inicio, { zone: 'America/Bogota' }).toJSDate(),
-      fin: dto.fin
-        ? DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate()
-        : null,
+      inicio,
+      fin,
     });
-    return this.repo.save(entity);
+    const nuevo = await this.repo.save(entity);
+
+    await this.actualizarSesionOtro(dto.maquina, inicio);
+
+    return nuevo;
   }
 
   findAll() {
@@ -39,15 +65,28 @@ export class EstadoMaquinaService {
   }
 
   async update(id: string, dto: UpdateEstadoMaquinaDto) {
-    const estado = await this.repo.findOne({ where: { id } });
+    const estado = await this.repo.findOne({
+      where: { id },
+      relations: ['maquina'],
+    });
     if (!estado) throw new NotFoundException('Estado de máquina no encontrado');
     if (dto.maquina) estado.maquina = { id: dto.maquina } as any;
     if (dto.mantenimiento !== undefined) estado.mantenimiento = dto.mantenimiento;
     if (dto.inicio)
-      estado.inicio = DateTime.fromJSDate(dto.inicio, { zone: 'America/Bogota' }).toJSDate();
+      estado.inicio = DateTime.fromJSDate(dto.inicio, {
+        zone: 'America/Bogota',
+      }).toJSDate();
     if (dto.fin)
-      estado.fin = DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate();
-    return this.repo.save(estado);
+      estado.fin = DateTime.fromJSDate(dto.fin, {
+        zone: 'America/Bogota',
+      }).toJSDate();
+    const actualizado = await this.repo.save(estado);
+
+    if (dto.fin) {
+      await this.restaurarSesionProduccion(estado.maquina.id, estado.fin);
+    }
+
+    return actualizado;
   }
 
   async remove(id: string) {
@@ -62,6 +101,50 @@ export class EstadoMaquinaService {
       where: { maquina: { id: maquinaId } },
       relations: ['maquina'],
       order: { inicio: 'DESC' },
+    });
+  }
+
+  private async actualizarSesionOtro(maquinaId: string, fecha: Date) {
+    const sesion = await this.sesionRepo.findOne({
+      where: { maquina: { id: maquinaId }, fechaFin: IsNull() },
+    });
+    if (!sesion) return;
+    const estados = await this.estadoSesionService.findBySesion(sesion.id);
+    const actual = estados.find((e) => e.fin === null);
+    if (actual?.estado === TipoEstadoSesion.OTRO) return;
+    if (actual)
+      await this.estadoSesionService.update(actual.id, { fin: fecha });
+    await this.estadoSesionService.create({
+      sesionTrabajo: sesion.id,
+      estado: TipoEstadoSesion.OTRO,
+      inicio: fecha,
+    });
+  }
+
+  private async restaurarSesionProduccion(
+    maquinaId: string,
+    fin: Date | null,
+  ) {
+    const sesion = await this.sesionRepo.findOne({
+      where: { maquina: { id: maquinaId }, fechaFin: IsNull() },
+      relations: ['trabajador'],
+    });
+    if (!sesion || !fin) return;
+    const maquinaActiva = await this.repo.findOne({
+      where: { maquina: { id: maquinaId }, fin: IsNull() },
+    });
+    const trabajadorActivo = await this.estadoTrabajadorRepo.findOne({
+      where: { trabajador: { id: sesion.trabajador.id }, fin: IsNull() },
+    });
+    if (maquinaActiva || trabajadorActivo) return;
+    const estados = await this.estadoSesionService.findBySesion(sesion.id);
+    const actual = estados.find((e) => e.fin === null);
+    if (!actual || actual.estado !== TipoEstadoSesion.OTRO) return;
+    await this.estadoSesionService.update(actual.id, { fin });
+    await this.estadoSesionService.create({
+      sesionTrabajo: sesion.id,
+      estado: TipoEstadoSesion.PRODUCCION,
+      inicio: fin,
     });
   }
 }

--- a/src/estado-trabajador/estado-trabajador.module.ts
+++ b/src/estado-trabajador/estado-trabajador.module.ts
@@ -3,9 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EstadoTrabajador } from './estado-trabajador.entity';
 import { EstadoTrabajadorService } from './estado-trabajador.service';
 import { EstadoTrabajadorController } from './estado-trabajador.controller';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
+import { EstadoSesionModule } from '../estado-sesion/estado-sesion.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([EstadoTrabajador])],
+  imports: [
+    TypeOrmModule.forFeature([EstadoTrabajador, SesionTrabajo, EstadoMaquina]),
+    EstadoSesionModule,
+  ],
   controllers: [EstadoTrabajadorController],
   providers: [EstadoTrabajadorService],
   exports: [EstadoTrabajadorService],

--- a/src/estado-trabajador/estado-trabajador.service.ts
+++ b/src/estado-trabajador/estado-trabajador.service.ts
@@ -1,28 +1,54 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, IsNull } from 'typeorm';
 import { DateTime } from 'luxon';
 import { EstadoTrabajador } from './estado-trabajador.entity';
 import { CreateEstadoTrabajadorDto } from './dto/create-estado-trabajador.dto';
 import { UpdateEstadoTrabajadorDto } from './dto/update-estado-trabajador.dto';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
+import { TipoEstadoSesion } from '../estado-sesion/estado-sesion.entity';
+import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 
 @Injectable()
 export class EstadoTrabajadorService {
   constructor(
     @InjectRepository(EstadoTrabajador)
     private readonly repo: Repository<EstadoTrabajador>,
+    @InjectRepository(SesionTrabajo)
+    private readonly sesionRepo: Repository<SesionTrabajo>,
+    @InjectRepository(EstadoMaquina)
+    private readonly estadoMaquinaRepo: Repository<EstadoMaquina>,
+    private readonly estadoSesionService: EstadoSesionService,
   ) {}
 
   async create(dto: CreateEstadoTrabajadorDto) {
+    const inicio = DateTime.fromJSDate(dto.inicio, {
+      zone: 'America/Bogota',
+    }).toJSDate();
+    const fin = dto.fin
+      ? DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate()
+      : null;
+
+    const abiertos = await this.repo.find({
+      where: { trabajador: { id: dto.trabajador }, fin: IsNull() },
+    });
+    for (const a of abiertos) {
+      a.fin = inicio;
+      await this.repo.save(a);
+    }
+
     const entity = this.repo.create({
       trabajador: { id: dto.trabajador } as any,
       descanso: dto.descanso,
-      inicio: DateTime.fromJSDate(dto.inicio, { zone: 'America/Bogota' }).toJSDate(),
-      fin: dto.fin
-        ? DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate()
-        : null,
+      inicio,
+      fin,
     });
-    return this.repo.save(entity);
+    const nuevo = await this.repo.save(entity);
+
+    await this.actualizarSesionOtro(dto.trabajador, inicio);
+
+    return nuevo;
   }
 
   findAll() {
@@ -39,16 +65,32 @@ export class EstadoTrabajadorService {
   }
 
   async update(id: string, dto: UpdateEstadoTrabajadorDto) {
-    const estado = await this.repo.findOne({ where: { id } });
+    const estado = await this.repo.findOne({
+      where: { id },
+      relations: ['trabajador'],
+    });
     if (!estado) throw new NotFoundException('Estado de trabajador no encontrado');
     if (dto.trabajador)
       estado.trabajador = { id: dto.trabajador } as any;
     if (dto.descanso !== undefined) estado.descanso = dto.descanso;
     if (dto.inicio)
-      estado.inicio = DateTime.fromJSDate(dto.inicio, { zone: 'America/Bogota' }).toJSDate();
+      estado.inicio = DateTime.fromJSDate(dto.inicio, {
+        zone: 'America/Bogota',
+      }).toJSDate();
     if (dto.fin)
-      estado.fin = DateTime.fromJSDate(dto.fin, { zone: 'America/Bogota' }).toJSDate();
-    return this.repo.save(estado);
+      estado.fin = DateTime.fromJSDate(dto.fin, {
+        zone: 'America/Bogota',
+      }).toJSDate();
+    const actualizado = await this.repo.save(estado);
+
+    if (dto.fin) {
+      await this.restaurarSesionProduccion(
+        estado.trabajador.id,
+        estado.fin,
+      );
+    }
+
+    return actualizado;
   }
 
   async remove(id: string) {
@@ -63,6 +105,50 @@ export class EstadoTrabajadorService {
       where: { trabajador: { id: trabajadorId } },
       relations: ['trabajador'],
       order: { inicio: 'DESC' },
+    });
+  }
+
+  private async actualizarSesionOtro(trabajadorId: string, fecha: Date) {
+    const sesion = await this.sesionRepo.findOne({
+      where: { trabajador: { id: trabajadorId }, fechaFin: IsNull() },
+    });
+    if (!sesion) return;
+    const estados = await this.estadoSesionService.findBySesion(sesion.id);
+    const actual = estados.find((e) => e.fin === null);
+    if (actual?.estado === TipoEstadoSesion.OTRO) return;
+    if (actual)
+      await this.estadoSesionService.update(actual.id, { fin: fecha });
+    await this.estadoSesionService.create({
+      sesionTrabajo: sesion.id,
+      estado: TipoEstadoSesion.OTRO,
+      inicio: fecha,
+    });
+  }
+
+  private async restaurarSesionProduccion(
+    trabajadorId: string,
+    fin: Date | null,
+  ) {
+    const sesion = await this.sesionRepo.findOne({
+      where: { trabajador: { id: trabajadorId }, fechaFin: IsNull() },
+      relations: ['maquina'],
+    });
+    if (!sesion || !fin) return;
+    const trabajadorActivo = await this.repo.findOne({
+      where: { trabajador: { id: trabajadorId }, fin: IsNull() },
+    });
+    const maquinaActiva = await this.estadoMaquinaRepo.findOne({
+      where: { maquina: { id: sesion.maquina.id }, fin: IsNull() },
+    });
+    if (trabajadorActivo || maquinaActiva) return;
+    const estados = await this.estadoSesionService.findBySesion(sesion.id);
+    const actual = estados.find((e) => e.fin === null);
+    if (!actual || actual.estado !== TipoEstadoSesion.OTRO) return;
+    await this.estadoSesionService.update(actual.id, { fin });
+    await this.estadoSesionService.create({
+      sesionTrabajo: sesion.id,
+      estado: TipoEstadoSesion.PRODUCCION,
+      inicio: fin,
     });
   }
 }


### PR DESCRIPTION
## Summary
- close any existing worker/machine state before opening a new one
- update session state to `otro` during non-production statuses and revert to `produccion` when cleared
- wire up modules with session and cross-state dependencies

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment of an `any` value etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689250dce9b48325a2caaffb7b38e528