### PR TITLE
feat: link machine minutes to session and step

### DIFF
--- a/src/registro-minuto/dto/acumulador.dto.ts
+++ b/src/registro-minuto/dto/acumulador.dto.ts
@@ -2,7 +2,10 @@ import { IsUUID, IsIn, IsDateString } from 'class-validator'
 
 export class AcumuladorDto {
   @IsUUID()
-  sesionTrabajo: string
+  maquina: string
+
+  @IsUUID()
+  pasoSesionTrabajo: string
 
   @IsIn(['pedal', 'pieza'])
   tipo: 'pedal' | 'pieza'

--- a/src/registro-minuto/dto/create-registro-minuto.dto.ts
+++ b/src/registro-minuto/dto/create-registro-minuto.dto.ts
@@ -4,6 +4,9 @@ export class CreateRegistroMinutoDto {
   @IsUUID()
   sesionTrabajo: string
 
+  @IsUUID()
+  pasoSesionTrabajo: string
+
   @IsDateString()
   minutoInicio: string
 

--- a/src/registro-minuto/registro-minuto.controller.ts
+++ b/src/registro-minuto/registro-minuto.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Post, Body, Get, Param } from '@nestjs/common'
 import { RegistroMinutoService } from './registro-minuto.service'
-import { CreateRegistroMinutoDto } from './dto/create-registro-minuto.dto'
 import { AcumuladorDto } from './dto/acumulador.dto'
 
 @Controller('registro-minuto')
@@ -10,8 +9,8 @@ export class RegistroMinutoController {
   @Post('acumular')
   async acumular(@Body() body: AcumuladorDto) {
     
-    const { sesionTrabajo, tipo, minutoInicio } = body
-    await this.service.acumular(sesionTrabajo, tipo, minutoInicio)
+    const { maquina, pasoSesionTrabajo, tipo, minutoInicio } = body
+    await this.service.acumular(maquina, pasoSesionTrabajo, tipo, minutoInicio)
     return { ok: true }
   }
 

--- a/src/registro-minuto/registro-minuto.entity.ts
+++ b/src/registro-minuto/registro-minuto.entity.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, BaseEntity } from 'typeorm'
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity'
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity'
 
 @Entity('registro_minuto')
 export class RegistroMinuto extends BaseEntity {
@@ -9,6 +10,10 @@ export class RegistroMinuto extends BaseEntity {
   @ManyToOne(() => SesionTrabajo, { nullable: false })
   @JoinColumn({ name: 'sesionTrabajoId' })
   sesionTrabajo: SesionTrabajo
+
+  @ManyToOne(() => SesionTrabajoPaso, { nullable: false })
+  @JoinColumn({ name: 'pasoSesionTrabajoId' })
+  pasoSesionTrabajo: SesionTrabajoPaso
 
   @Column({ type: 'timestamp' })
   minutoInicio: Date


### PR DESCRIPTION
## Summary
- allow minute accumulation to accept machine and step-session identifiers
- record paso-sesion-trabajo on each minute record
- resolve active session by machine and update step counters when saving

## Testing
- `npm test` (fails: Nest can't resolve dependencies)
- `npx eslint "{src,apps,libs,test}/**/*.ts"` (fails: 437 problems)


------
https://chatgpt.com/codex/tasks/task_e_689534483abc8325917ecacad45d7e46