### PR TITLE
Pause step session during machine maintenance

### DIFF
--- a/src/estado-maquina/estado-maquina.module.ts
+++ b/src/estado-maquina/estado-maquina.module.ts
@@ -6,11 +6,19 @@ import { EstadoMaquinaController } from './estado-maquina.controller';
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
 import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
 import { EstadoSesionModule } from '../estado-sesion/estado-sesion.module';
+import { PausaPasoSesionModule } from '../pausa-paso-sesion/pausa-paso-sesion.module';
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([EstadoMaquina, SesionTrabajo, EstadoTrabajador]),
+    TypeOrmModule.forFeature([
+      EstadoMaquina,
+      SesionTrabajo,
+      EstadoTrabajador,
+      SesionTrabajoPaso,
+    ]),
     EstadoSesionModule,
+    PausaPasoSesionModule,
   ],
   controllers: [EstadoMaquinaController],
   providers: [EstadoMaquinaService],

--- a/src/estado-maquina/estado-maquina.service.ts
+++ b/src/estado-maquina/estado-maquina.service.ts
@@ -10,6 +10,8 @@ import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity'
 import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
 import { TipoEstadoSesion } from '../estado-sesion/estado-sesion.entity';
 import { PasoProduccionService } from '../paso-produccion/paso-produccion.service';
+import { PausaPasoSesionService } from '../pausa-paso-sesion/pausa-paso-sesion.service';
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
 
 @Injectable()
 export class EstadoMaquinaService {
@@ -22,6 +24,7 @@ export class EstadoMaquinaService {
     private readonly estadoTrabajadorRepo: Repository<EstadoTrabajador>,
     private readonly estadoSesionService: EstadoSesionService,
     private readonly pasoProduccionService: PasoProduccionService,
+    private readonly pausaPasoSesionService: PausaPasoSesionService,
   ) {}
 
   async create(dto: CreateEstadoMaquinaDto) {
@@ -45,6 +48,10 @@ export class EstadoMaquinaService {
       fin: null,
     });
     const nuevo = await this.repo.save(entity);
+
+    if (dto.mantenimiento) {
+      await this.pausarPasoSesion(dto.maquina, inicio);
+    }
 
     await this.actualizarSesionOtro(dto.maquina, inicio);
 
@@ -96,6 +103,26 @@ export class EstadoMaquinaService {
       relations: ['maquina'],
       order: { inicio: 'DESC' },
     });
+  }
+
+  private async pausarPasoSesion(maquinaId: string, fecha: Date) {
+    const sesion = await this.sesionRepo.findOne({
+      where: { maquina: { id: maquinaId }, fechaFin: IsNull() },
+    });
+    if (!sesion) return;
+
+    const stpRepo = this.repo.manager.getRepository(SesionTrabajoPaso);
+    const pasos = await stpRepo.find({
+      where: { sesionTrabajo: { id: sesion.id } },
+    });
+
+    for (const paso of pasos) {
+      const pausaActiva = await this.pausaPasoSesionService.findActive(paso.id);
+      if (!pausaActiva) {
+        await this.pausaPasoSesionService.create(paso.id, fecha);
+        break;
+      }
+    }
   }
 
   private async actualizarSesionOtro(maquinaId: string, fecha: Date) {


### PR DESCRIPTION
## Summary
- Pause active session step when a machine enters maintenance
- Provide PausaPasoSesion access within EstadoMaquina module

## Testing
- `npm test` *(fails: Nest can't resolve dependencies of the EstadoSesionService and SesionTrabajoService)*

------
https://chatgpt.com/codex/tasks/task_e_6896276c4fe883258d31a7b29099f516