### PR TITLE
Prevent session finalization during worker break

### DIFF
--- a/src/estado-sesion/estado-sesion.service.spec.ts
+++ b/src/estado-sesion/estado-sesion.service.spec.ts
@@ -5,6 +5,7 @@ import { EstadoSesionService } from './estado-sesion.service';
 import { EstadoSesion } from './estado-sesion.entity';
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
 import { BadRequestException } from '@nestjs/common';
+import { PasoProduccionService } from '../paso-produccion/paso-produccion.service';
 
 describe('EstadoSesionService', () => {
   let service: EstadoSesionService;
@@ -16,6 +17,7 @@ describe('EstadoSesionService', () => {
       providers: [
         EstadoSesionService,
         { provide: getRepositoryToken(EstadoSesion), useClass: Repository },
+        { provide: PasoProduccionService, useValue: { actualizarEstadoPorSesion: jest.fn() } },
       ],
     }).compile();
 

--- a/src/sesion-trabajo/sesion-trabajo.service.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.spec.ts
@@ -6,6 +6,9 @@ import { SesionTrabajo } from './sesion-trabajo.entity';
 import { RegistroMinutoService } from '../registro-minuto/registro-minuto.service';
 import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
 import { ConfiguracionService } from '../configuracion/configuracion.service';
+import { EstadoSesion } from '../estado-sesion/estado-sesion.entity';
+import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
+import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 
 describe('SesionTrabajoService', () => {
   let service: SesionTrabajoService;
@@ -15,6 +18,9 @@ describe('SesionTrabajoService', () => {
       providers: [
         SesionTrabajoService,
         { provide: getRepositoryToken(SesionTrabajo), useClass: Repository },
+        { provide: getRepositoryToken(EstadoSesion), useClass: Repository },
+        { provide: getRepositoryToken(EstadoTrabajador), useClass: Repository },
+        { provide: getRepositoryToken(EstadoMaquina), useClass: Repository },
         { provide: RegistroMinutoService, useValue: {} },
         { provide: EstadoSesionService, useValue: {} },
         { provide: ConfiguracionService, useValue: {} },


### PR DESCRIPTION
## Summary
- block session finalization if the worker is on break
- stub required providers in unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896402933ac8325b4532d277de461e9