### PR TITLE
fix: provide PasoProduccionService to pause session

### DIFF
--- a/src/pausa-paso-sesion/pausa-paso-sesion.module.ts
+++ b/src/pausa-paso-sesion/pausa-paso-sesion.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PausaPasoSesion } from './pausa-paso-sesion.entity';
 import { PausaPasoSesionService } from './pausa-paso-sesion.service';
+import { PasoProduccionModule } from '../paso-produccion/paso-produccion.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PausaPasoSesion])],
+  imports: [TypeOrmModule.forFeature([PausaPasoSesion]), PasoProduccionModule],
   providers: [PausaPasoSesionService],
   exports: [PausaPasoSesionService],
 })


### PR DESCRIPTION
## Summary
- inject PasoProduccionService into PausaPasoSesionService by importing PasoProduccionModule

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b790093f48325a39f3adcde145460