### PR TITLE
fix: inject PasoProduccionService into session modules

### DIFF
--- a/src/pausa-paso-sesion/pausa-paso-sesion.module.ts
+++ b/src/pausa-paso-sesion/pausa-paso-sesion.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PausaPasoSesion } from './pausa-paso-sesion.entity';
 import { PausaPasoSesionService } from './pausa-paso-sesion.service';
+import { PasoProduccionModule } from '../paso-produccion/paso-produccion.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PausaPasoSesion])],
+  imports: [TypeOrmModule.forFeature([PausaPasoSesion]), PasoProduccionModule],
   providers: [PausaPasoSesionService],
   exports: [PausaPasoSesionService],
 })

--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.module.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.module.ts
@@ -4,9 +4,14 @@ import { SesionTrabajoPaso } from './sesion-trabajo-paso.entity';
 import { SesionTrabajoPasoService } from './sesion-trabajo-paso.service';
 import { SesionTrabajoPasoController } from './sesion-trabajo-paso.controller';
 import { PausaPasoSesionModule } from '../pausa-paso-sesion/pausa-paso-sesion.module';
+import { PasoProduccionModule } from '../paso-produccion/paso-produccion.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SesionTrabajoPaso]), PausaPasoSesionModule],
+  imports: [
+    TypeOrmModule.forFeature([SesionTrabajoPaso]),
+    PausaPasoSesionModule,
+    PasoProduccionModule,
+  ],
   providers: [SesionTrabajoPasoService],
   controllers: [SesionTrabajoPasoController],
 })


### PR DESCRIPTION
## Summary
- import PasoProduccionModule into pause and work-step modules so PasoProduccionService can be injected

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b790093f48325a39f3adcde145460