### PR TITLE
Add area and production tracking modules with machine area linkage

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,8 @@ import { MaterialOrdenModule } from './material-orden/material-orden.module';
 import { ConfiguracionModule } from './configuracion/configuracion.module';
 import { TimezoneModule } from './common/timezone.module';
 import { TimezoneInterceptor } from './common/timezone.interceptor';
+import { AreaModule } from './area/area.module';
+import { ProduccionDiariaModule } from './produccion-diaria/produccion-diaria.module';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -73,6 +75,9 @@ import * as path from 'path';
     EmpresaModule,
 
     MaterialOrdenModule,
+
+    AreaModule,
+    ProduccionDiariaModule,
 
     AuthModule,
   ],

--- a/src/area/area.controller.ts
+++ b/src/area/area.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Put,
+  Delete,
+  Body,
+  Param,
+} from '@nestjs/common';
+import { AreaService } from './area.service';
+import { CreateAreaDto } from './dto/create-area.dto';
+import { UpdateAreaDto } from './dto/update-area.dto';
+
+@Controller('areas')
+export class AreaController {
+  constructor(private readonly service: AreaService) {}
+
+  @Post()
+  crearArea(@Body() dto: CreateAreaDto) {
+    return this.service.create(dto);
+  }
+
+  @Get(':id')
+  obtenerArea(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Get()
+  listarAreas() {
+    return this.service.findAll();
+  }
+
+  @Put(':id')
+  actualizarArea(@Param('id') id: string, @Body() dto: UpdateAreaDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  eliminarArea(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/area/area.entity.ts
+++ b/src/area/area.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('area')
+export class Area {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  nombre: string;
+}

--- a/src/area/area.module.ts
+++ b/src/area/area.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Area } from './area.entity';
+import { AreaService } from './area.service';
+import { AreaController } from './area.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Area])],
+  controllers: [AreaController],
+  providers: [AreaService],
+  exports: [AreaService],
+})
+export class AreaModule {}

--- a/src/area/area.service.ts
+++ b/src/area/area.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Area } from './area.entity';
+import { CreateAreaDto } from './dto/create-area.dto';
+import { UpdateAreaDto } from './dto/update-area.dto';
+
+@Injectable()
+export class AreaService {
+  constructor(
+    @InjectRepository(Area) private readonly repo: Repository<Area>,
+  ) {}
+
+  create(dto: CreateAreaDto) {
+    const area = this.repo.create(dto);
+    return this.repo.save(area);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  async findOne(id: string) {
+    const area = await this.repo.findOne({ where: { id } });
+    if (!area) throw new NotFoundException('Área no encontrada');
+    return area;
+  }
+
+  async update(id: string, dto: UpdateAreaDto) {
+    const area = await this.repo.preload({ id, ...dto });
+    if (!area) throw new NotFoundException('Área no encontrada');
+    return this.repo.save(area);
+  }
+
+  async remove(id: string) {
+    const area = await this.repo.findOne({ where: { id } });
+    if (!area) throw new NotFoundException('Área no encontrada');
+    await this.repo.remove(area);
+    return { deleted: true };
+  }
+}

--- a/src/area/dto/create-area.dto.ts
+++ b/src/area/dto/create-area.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateAreaDto {
+  @IsString()
+  nombre: string;
+}

--- a/src/area/dto/index.ts
+++ b/src/area/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './create-area.dto';
+export * from './update-area.dto';

--- a/src/area/dto/update-area.dto.ts
+++ b/src/area/dto/update-area.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class UpdateAreaDto {
+  @IsOptional()
+  @IsString()
+  nombre?: string;
+}

--- a/src/maquina/dto/create-maquina.dto.ts
+++ b/src/maquina/dto/create-maquina.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, Length, IsISO8601, IsEnum } from 'class-validator'
+import { IsString, Length, IsISO8601, IsEnum, IsUUID } from 'class-validator'
 
 export enum TipoMaquina {
   TROQUELADORA = 'troqueladora',
@@ -26,6 +26,9 @@ export class CreateMaquinaDto {
 
   @IsEnum(TipoMaquina)
   tipo: TipoMaquina
+
+  @IsUUID()
+  areaId: string
 
   @IsString()
   @Length(0, 255)

--- a/src/maquina/dto/update-maquina.dto.ts
+++ b/src/maquina/dto/update-maquina.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, Length, IsISO8601, IsEnum, IsOptional } from 'class-validator'
+import { IsString, Length, IsISO8601, IsEnum, IsOptional, IsUUID } from 'class-validator'
 import { TipoMaquina } from './create-maquina.dto'
 
 export class UpdateMaquinaDto {
@@ -25,4 +25,8 @@ export class UpdateMaquinaDto {
   @IsString()
   @Length(0, 255)
   observaciones?: string
+
+  @IsOptional()
+  @IsUUID()
+  areaId?: string
 }

--- a/src/maquina/maquina.entity.ts
+++ b/src/maquina/maquina.entity.ts
@@ -5,7 +5,16 @@ export enum TipoMaquina {
   VULCANIZADORA = 'vulcanizadora'
 }
 
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Area } from '../area/area.entity';
 
 @Entity()
 export class Maquina {
@@ -29,6 +38,10 @@ export class Maquina {
 
   @Column({ length: 255, nullable: true })
   observaciones: string;
+
+  @ManyToOne(() => Area, { nullable: false })
+  @JoinColumn({ name: 'areaId' })
+  area: Area;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/produccion-diaria/produccion-diaria.controller.ts
+++ b/src/produccion-diaria/produccion-diaria.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ProduccionDiariaService } from './produccion-diaria.service';
+
+@Controller('produccion')
+export class ProduccionDiariaController {
+  constructor(private readonly service: ProduccionDiariaService) {}
+
+  @Get('diaria/mes-actual')
+  obtenerProduccionDiariaMesActual(@Query('areaId') areaId?: string) {
+    return this.service.obtenerProduccionDiariaMesActual(areaId);
+  }
+
+  @Get('diaria/ultimos-30-dias')
+  obtenerProduccionDiariaUltimos30Dias(@Query('areaId') areaId?: string) {
+    return this.service.obtenerProduccionDiariaUltimos30Dias(areaId);
+  }
+
+  @Get('mensual/ano-actual')
+  obtenerProduccionMensualAnoActual(@Query('areaId') areaId?: string) {
+    return this.service.obtenerProduccionMensualAnoActual(areaId);
+  }
+
+  @Get('mensual/ultimos-12-meses')
+  obtenerProduccionMensualUltimos12Meses(@Query('areaId') areaId?: string) {
+    return this.service.obtenerProduccionMensualUltimos12Meses(areaId);
+  }
+}

--- a/src/produccion-diaria/produccion-diaria.entity.ts
+++ b/src/produccion-diaria/produccion-diaria.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Area } from '../area/area.entity';
+
+@Entity('produccion_diaria')
+@Index(['fecha', 'areaId'])
+export class ProduccionDiaria {
+  @PrimaryColumn({ type: 'date' })
+  fecha: Date;
+
+  @PrimaryColumn('uuid')
+  areaId: string;
+
+  @ManyToOne(() => Area, { nullable: false })
+  @JoinColumn({ name: 'areaId' })
+  area: Area;
+
+  @Column('int', { default: 0 })
+  piezas: number;
+
+  @Column('int', { default: 0 })
+  pedaleadas: number;
+
+  @Column('int', { default: 0 })
+  sesionesCerradas: number;
+}

--- a/src/produccion-diaria/produccion-diaria.module.ts
+++ b/src/produccion-diaria/produccion-diaria.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProduccionDiaria } from './produccion-diaria.entity';
+import { ProduccionDiariaService } from './produccion-diaria.service';
+import { ProduccionDiariaController } from './produccion-diaria.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProduccionDiaria])],
+  controllers: [ProduccionDiariaController],
+  providers: [ProduccionDiariaService],
+  exports: [ProduccionDiariaService],
+})
+export class ProduccionDiariaModule {}

--- a/src/produccion-diaria/produccion-diaria.service.ts
+++ b/src/produccion-diaria/produccion-diaria.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DateTime } from 'luxon';
+import { ProduccionDiaria } from './produccion-diaria.entity';
+
+@Injectable()
+export class ProduccionDiariaService {
+  private readonly zone = 'America/Bogota';
+
+  constructor(
+    @InjectRepository(ProduccionDiaria)
+    private readonly repo: Repository<ProduccionDiaria>,
+  ) {}
+
+  async obtenerProduccionDiariaMesActual(areaId?: string) {
+    const now = DateTime.now().setZone(this.zone);
+    const inicio = now.startOf('month');
+    const fin = now.endOf('month');
+    return this.obtenerDiariaRango(inicio, fin, areaId);
+  }
+
+  async obtenerProduccionDiariaUltimos30Dias(areaId?: string) {
+    const fin = DateTime.now().setZone(this.zone).startOf('day');
+    const inicio = fin.minus({ days: 29 });
+    return this.obtenerDiariaRango(inicio, fin, areaId);
+  }
+
+  async obtenerProduccionMensualAnoActual(areaId?: string) {
+    const now = DateTime.now().setZone(this.zone);
+    const inicio = now.startOf('year');
+    const fin = now.endOf('year');
+    return this.obtenerMensualRango(inicio, fin, areaId);
+  }
+
+  async obtenerProduccionMensualUltimos12Meses(areaId?: string) {
+    const fin = DateTime.now().setZone(this.zone).startOf('month');
+    const inicio = fin.minus({ months: 11 });
+    const finMes = fin.endOf('month');
+    return this.obtenerMensualRango(inicio, finMes, areaId);
+  }
+
+  private async obtenerDiariaRango(
+    inicio: DateTime,
+    fin: DateTime,
+    areaId?: string,
+  ) {
+    const qb = this.repo
+      .createQueryBuilder('p')
+      .select('p.fecha', 'fecha')
+      .addSelect('SUM(p.piezas)', 'piezas')
+      .addSelect('SUM(p.pedaleadas)', 'pedaleadas')
+      .addSelect('SUM(p.sesionesCerradas)', 'sesionesCerradas')
+      .where('p.fecha BETWEEN :inicio AND :fin', {
+        inicio: inicio.toISODate(),
+        fin: fin.toISODate(),
+      })
+      .groupBy('p.fecha')
+      .orderBy('p.fecha', 'ASC');
+    if (areaId) qb.andWhere('p.areaId = :areaId', { areaId });
+    const rows = await qb.getRawMany();
+    const map = new Map(
+      rows.map((r) => [
+        r.fecha,
+        {
+          piezas: Number(r.piezas) || 0,
+          pedaleadas: Number(r.pedaleadas) || 0,
+          sesionesCerradas: Number(r.sesionesCerradas) || 0,
+        },
+      ]),
+    );
+    const resultado = [];
+    for (let d = inicio; d <= fin; d = d.plus({ days: 1 })) {
+      const key = d.toISODate();
+      const totales = map.get(key) || {
+        piezas: 0,
+        pedaleadas: 0,
+        sesionesCerradas: 0,
+      };
+      resultado.push({ fecha: key, areaId: areaId ?? null, ...totales });
+    }
+    return resultado;
+  }
+
+  private async obtenerMensualRango(
+    inicio: DateTime,
+    fin: DateTime,
+    areaId?: string,
+  ) {
+    const qb = this.repo
+      .createQueryBuilder('p')
+      .select("DATE_TRUNC('month', p.fecha)", 'mes')
+      .addSelect('SUM(p.piezas)', 'piezas')
+      .addSelect('SUM(p.pedaleadas)', 'pedaleadas')
+      .addSelect('SUM(p.sesionesCerradas)', 'sesionesCerradas')
+      .where('p.fecha BETWEEN :inicio AND :fin', {
+        inicio: inicio.toISODate(),
+        fin: fin.toISODate(),
+      })
+      .groupBy("DATE_TRUNC('month', p.fecha)")
+      .orderBy('mes', 'ASC');
+    if (areaId) qb.andWhere('p.areaId = :areaId', { areaId });
+    const rows = await qb.getRawMany();
+    const map = new Map(
+      rows.map((r) => [
+        DateTime.fromJSDate(r.mes).toISODate(),
+        {
+          piezas: Number(r.piezas) || 0,
+          pedaleadas: Number(r.pedaleadas) || 0,
+          sesionesCerradas: Number(r.sesionesCerradas) || 0,
+        },
+      ]),
+    );
+    const resultado = [];
+    for (
+      let m = inicio.startOf('month');
+      m <= fin.startOf('month');
+      m = m.plus({ months: 1 })
+    ) {
+      const key = m.toISODate();
+      const totales = map.get(key) || {
+        piezas: 0,
+        pedaleadas: 0,
+        sesionesCerradas: 0,
+      };
+      resultado.push({ mes: key, areaId: areaId ?? null, ...totales });
+    }
+    return resultado;
+  }
+}


### PR DESCRIPTION
## Summary
- add Area module with CRUD endpoints
- track daily production by area and expose reporting endpoints
- link machines to areas and require area selection

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment and unused vars across existing code)*

------
https://chatgpt.com/codex/tasks/task_e_689bcbf2d4308325939bd856c89cc496