### PR TITLE
Include worker and machine in session lookup

### DIFF
--- a/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
+++ b/src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts
@@ -197,14 +197,24 @@ export class SesionTrabajoPasoService {
   findByPaso(pasoId: string) {
     return this.repo.find({
       where: { pasoOrden: { id: pasoId } },
-      relations: ['sesionTrabajo', 'pasoOrden'],
+      relations: [
+        'sesionTrabajo',
+        'sesionTrabajo.trabajador',
+        'sesionTrabajo.maquina',
+        'pasoOrden',
+      ],
     });
   }
 
   findBySesion(sesionId: string) {
     return this.repo.find({
       where: { sesionTrabajo: { id: sesionId } },
-      relations: ['sesionTrabajo', 'pasoOrden'],
+      relations: [
+        'sesionTrabajo',
+        'sesionTrabajo.trabajador',
+        'sesionTrabajo.maquina',
+        'pasoOrden',
+      ],
     });
   }
 


### PR DESCRIPTION
## Summary
- load worker and machine relations when retrieving session-step links by step or session

## Testing
- `npm test`
- `npx eslint src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts` *(fails: 'EstadoPasoOrden' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bf954fbec8325a43be1d34464fe04