### PR TITLE
refactor(registro-minuto): buscar paso sesion por paso

### DIFF
--- a/src/registro-minuto/dto/acumulador.dto.ts
+++ b/src/registro-minuto/dto/acumulador.dto.ts
@@ -5,7 +5,7 @@ export class AcumuladorDto {
   maquina: string
 
   @IsUUID()
-  pasoSesionTrabajo: string
+  paso: string
 
   @IsIn(['pedal', 'pieza'])
   tipo: 'pedal' | 'pieza'

--- a/src/registro-minuto/registro-minuto.controller.ts
+++ b/src/registro-minuto/registro-minuto.controller.ts
@@ -8,9 +8,9 @@ export class RegistroMinutoController {
 
   @Post('acumular')
   async acumular(@Body() body: AcumuladorDto) {
-    
-    const { maquina, pasoSesionTrabajo, tipo, minutoInicio } = body
-    await this.service.acumular(maquina, pasoSesionTrabajo, tipo, minutoInicio)
+
+    const { maquina, paso, tipo, minutoInicio } = body
+    await this.service.acumular(maquina, paso, tipo, minutoInicio)
     return { ok: true }
   }
 

--- a/src/registro-minuto/registro-minuto.service.ts
+++ b/src/registro-minuto/registro-minuto.service.ts
@@ -52,7 +52,7 @@ export class RegistroMinutoService {
 
   async acumular(
     maquinaId: string,
-    pasoSesionTrabajoId: string,
+    pasoId: string,
     tipo: 'pedal' | 'pieza',
     minutoInicio: string,
   ) {
@@ -60,11 +60,20 @@ export class RegistroMinutoService {
 
     if (!sesion) return;
 
+    const pasoSesionTrabajo = await this.stpRepo.findOne({
+      where: {
+        sesionTrabajo: { id: sesion.id },
+        pasoOrden: { id: pasoId },
+      },
+    });
+
+    if (!pasoSesionTrabajo) return;
+
     await this.mutex.runExclusive(async () => {
       const fecha = DateTime.fromISO(minutoInicio, {
         zone: 'America/Bogota',
       }).toJSDate();
-      const clave = `${sesion.id}_${pasoSesionTrabajoId}_${fecha.toISOString()}`;
+      const clave = `${sesion.id}_${pasoSesionTrabajo.id}_${fecha.toISOString()}`;
       const actual = this.memoria.get(clave) || {
         pedaleadas: 0,
         piezasContadas: 0,


### PR DESCRIPTION
## Summary
- adjust AcumuladorDto and controller to accept `paso` instead of `pasoSesionTrabajo`
- resolve `SesionTrabajoPaso` from paso and active session before accumulating

## Testing
- `npm test`
- `npx eslint src/registro-minuto/dto/acumulador.dto.ts src/registro-minuto/registro-minuto.controller.ts src/registro-minuto/registro-minuto.service.ts` *(fails: Insert `;`, Async arrow function has no 'await' expression, Unsafe assignment, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689c04a700a08325b6743f15ba0468a1