### PR TITLE
Update daily production on minute records

### DIFF
--- a/src/registro-minuto/registro-minuto.module.ts
+++ b/src/registro-minuto/registro-minuto.module.ts
@@ -6,6 +6,7 @@ import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.en
 import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
 import { PasoProduccion } from '../paso-produccion/paso-produccion.entity';
 import { RegistroMinutoController } from './registro-minuto.controller';
+import { ProduccionDiariaModule } from '../produccion-diaria/produccion-diaria.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { RegistroMinutoController } from './registro-minuto.controller';
       SesionTrabajo,
       PasoProduccion,
     ]),
+    ProduccionDiariaModule,
   ],
   providers: [RegistroMinutoService],
   controllers: [RegistroMinutoController],

--- a/src/sesion-trabajo/sesion-trabajo.module.ts
+++ b/src/sesion-trabajo/sesion-trabajo.module.ts
@@ -9,7 +9,6 @@ import { EstadoSesion } from '../estado-sesion/estado-sesion.entity';
 import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
 import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 import { RegistroMinuto } from '../registro-minuto/registro-minuto.entity';
-import { ProduccionDiariaModule } from '../produccion-diaria/produccion-diaria.module';
 
 @Module({
   imports: [
@@ -22,7 +21,6 @@ import { ProduccionDiariaModule } from '../produccion-diaria/produccion-diaria.m
     ]),
     RegistroMinutoModule,
     EstadoSesionModule,
-    ProduccionDiariaModule,
   ],
   providers: [SesionTrabajoService],
   controllers: [SesionTrabajoController],


### PR DESCRIPTION
## Summary
- stop updating daily production when closing a session
- increment daily production whenever minute records are saved or listed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb5c93fd083259760aac7c53c8e1d