### PR TITLE
feat: allow admin creation with pause

### DIFF
--- a/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
+++ b/src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts
@@ -1,4 +1,4 @@
-import { IsUUID, IsNumber, IsOptional } from 'class-validator';
+import { IsUUID, IsNumber, IsOptional, IsBoolean } from 'class-validator';
 
 export class CreateSesionTrabajoPasoDto {
   @IsUUID()
@@ -11,4 +11,7 @@ export class CreateSesionTrabajoPasoDto {
   @IsNumber()
   cantidadAsignada: number;
 
+  @IsOptional()
+  @IsBoolean()
+  porAdministrador?: boolean;
 }


### PR DESCRIPTION
## Summary
- add optional `porAdministrador` flag to session-step creation DTO
- create initial pause when admin flag is true
- reuse existing relation by resuming pause when flag is false

## Testing
- `npx eslint src/sesion-trabajo-paso/dto/create-sesion-trabajo-paso.dto.ts src/sesion-trabajo-paso/sesion-trabajo-paso.service.ts && echo 'Lint OK'`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e8654986483258ac1ada6b3ac9bdb