### PR TITLE
feat: obtener orden produccion por sesion

### DIFF
--- a/src/sesion-trabajo/sesion-trabajo.controller.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.ts
@@ -33,6 +33,11 @@ export class SesionTrabajoController {
     return this.service.findActivasResumen();
   }
 
+  @Get(':id/orden-produccion')
+  findOrdenProduccion(@Param('id') id: string) {
+    return this.service.findOrdenProduccion(id);
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.service.findOne(id);

--- a/src/sesion-trabajo/sesion-trabajo.module.ts
+++ b/src/sesion-trabajo/sesion-trabajo.module.ts
@@ -9,6 +9,7 @@ import { EstadoSesion } from '../estado-sesion/estado-sesion.entity';
 import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
 import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 import { RegistroMinuto } from '../registro-minuto/registro-minuto.entity';
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { RegistroMinuto } from '../registro-minuto/registro-minuto.entity';
       EstadoMaquina,
       SesionTrabajo,
       RegistroMinuto,
+      SesionTrabajoPaso,
     ]),
     RegistroMinutoModule,
     EstadoSesionModule,


### PR DESCRIPTION
## Summary
- expose `GET /sesiones-trabajo/:id/orden-produccion` to fetch a session's active production order
- lookup active (non-paused) step for the session and return its order info

## Testing
- `npm run lint` (fails: 117 problems)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa400c1488325b82655c51a732de9