### PR TITLE
feat: add esp32 flag to session endpoints

### DIFF
--- a/src/sesion-trabajo/sesion-trabajo.controller.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.spec.ts
@@ -4,17 +4,39 @@ import { SesionTrabajoService } from './sesion-trabajo.service';
 
 describe('SesionTrabajoController', () => {
   let controller: SesionTrabajoController;
+  let service: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SesionTrabajoController],
-      providers: [{ provide: SesionTrabajoService, useValue: {} }],
+      providers: [
+        {
+          provide: SesionTrabajoService,
+          useValue: {
+            create: jest.fn(),
+            findByMaquina: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<SesionTrabajoController>(SesionTrabajoController);
+    service = module.get<SesionTrabajoService>(SesionTrabajoService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should return id when esp32 flag is true on create', async () => {
+    service.create.mockResolvedValue({ id: 'abc' });
+    const result = await controller.create({} as any, 'true');
+    expect(result).toBe('abc');
+  });
+
+  it('should return id when esp32 flag is true on findSesionActiva', async () => {
+    service.findByMaquina.mockResolvedValue({ id: 'def' });
+    const result = await controller.findSesionActiva('1', 'true');
+    expect(result).toBe('def');
   });
 });

--- a/src/sesion-trabajo/sesion-trabajo.controller.ts
+++ b/src/sesion-trabajo/sesion-trabajo.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Param, Body, Put, Delete, Patch } from '@nestjs/common';
+import { Controller, Post, Get, Param, Body, Put, Delete, Patch, Query } from '@nestjs/common';
 import { SesionTrabajoService } from './sesion-trabajo.service';
 import { CreateSesionTrabajoDto } from './dto/create-sesion-trabajo.dto';
 import { UpdateSesionTrabajoDto } from './dto/update-sesion-trabajo.dto';
@@ -9,8 +9,13 @@ export class SesionTrabajoController {
   constructor(private readonly service: SesionTrabajoService) {}
 
   @Post()
-  create(@Body() dto: CreateSesionTrabajoDto) {
-    return this.service.create(dto);
+  async create(
+    @Body() dto: CreateSesionTrabajoDto,
+    @Query('esp32') esp32?: string,
+  ) {
+    const sesion = await this.service.create(dto);
+    if (esp32 === 'true') return sesion.id;
+    return sesion;
   }
 
   @Get()
@@ -60,8 +65,13 @@ export class SesionTrabajoController {
   }
 
   @Get('maquina/:id/activa')
-  findSesionActiva(@Param('id') id: string) {
-    return this.service.findByMaquina(id);
+  async findSesionActiva(
+    @Param('id') id: string,
+    @Query('esp32') esp32?: string,
+  ) {
+    const sesion = await this.service.findByMaquina(id);
+    if (esp32 === 'true') return sesion.id;
+    return sesion;
   }
 
 }

--- a/src/sesion-trabajo/sesion-trabajo.service.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.spec.ts
@@ -10,6 +10,7 @@ import { EstadoSesion } from '../estado-sesion/estado-sesion.entity';
 import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
 import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 import { ProduccionDiariaService } from '../produccion-diaria/produccion-diaria.service';
+import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
 
 describe('SesionTrabajoService', () => {
   let service: SesionTrabajoService;
@@ -22,6 +23,7 @@ describe('SesionTrabajoService', () => {
         { provide: getRepositoryToken(EstadoSesion), useClass: Repository },
         { provide: getRepositoryToken(EstadoTrabajador), useClass: Repository },
         { provide: getRepositoryToken(EstadoMaquina), useClass: Repository },
+        { provide: getRepositoryToken(SesionTrabajoPaso), useClass: Repository },
         { provide: RegistroMinutoService, useValue: {} },
         { provide: EstadoSesionService, useValue: {} },
         { provide: ConfiguracionService, useValue: {} },


### PR DESCRIPTION
## Summary
- return only session id when `esp32=true` during session creation
- return only session id when `esp32=true` fetching session by machine
- test esp32 flag behavior and provide missing repository in service spec

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignments, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9b2d7f0832581d0bd51242b4f68