### PR TITLE
Crear estado inicial inactivo para sesión y activarla al asignar paso

### DIFF
--- a/src/sesion-trabajo/sesion-trabajo.service.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.spec.ts
@@ -6,7 +6,7 @@ import { SesionTrabajo } from './sesion-trabajo.entity';
 import { RegistroMinutoService } from '../registro-minuto/registro-minuto.service';
 import { EstadoSesionService } from '../estado-sesion/estado-sesion.service';
 import { ConfiguracionService } from '../configuracion/configuracion.service';
-import { EstadoSesion } from '../estado-sesion/estado-sesion.entity';
+import { EstadoSesion, TipoEstadoSesion } from '../estado-sesion/estado-sesion.entity';
 import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity';
 import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 import { ProduccionDiariaService } from '../produccion-diaria/produccion-diaria.service';
@@ -14,9 +14,10 @@ import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.en
 
 describe('SesionTrabajoService', () => {
   let service: SesionTrabajoService;
+  let module: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         SesionTrabajoService,
         { provide: getRepositoryToken(SesionTrabajo), useClass: Repository },
@@ -39,5 +40,25 @@ describe('SesionTrabajoService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('incluye las relaciones sesion-trabajo-paso al buscar por id', async () => {
+    const sesionRepo = module.get<Repository<SesionTrabajo>>(getRepositoryToken(SesionTrabajo));
+    const estadoSesionRepo = module.get<Repository<EstadoSesion>>(getRepositoryToken(EstadoSesion));
+    const stpRepo = module.get<Repository<SesionTrabajoPaso>>(getRepositoryToken(SesionTrabajoPaso));
+
+    jest.spyOn(sesionRepo, 'findOne').mockResolvedValue({
+      id: '1',
+      trabajador: {},
+      maquina: {},
+    } as any);
+    jest.spyOn(estadoSesionRepo, 'findOne').mockResolvedValue(null);
+    const relaciones = [{ id: 'rel1' } as any];
+    jest.spyOn(stpRepo, 'find').mockResolvedValue(relaciones);
+
+    const result = await service.findOne('1');
+    expect(result.sesionesTrabajoPaso).toEqual(
+      relaciones.map((r) => ({ ...r, estado: TipoEstadoSesion.OTRO })),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Crear un registro de estado de sesión en INACTIVO al crear una sesión de trabajo
- Al asignar un paso a una sesión se finaliza el estado previo y se registra PRODUCCION
- Incluir las relaciones `sesion_trabajo_paso` al obtener una sesión por id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb4aa1f4c8325b458ed158b470e53