### PR TITLE
feat: add recent session records and state query endpoints

### DIFF
--- a/src/estado-maquina/estado-maquina.controller.ts
+++ b/src/estado-maquina/estado-maquina.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Post, Param, Body, Put, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Put,
+  Delete,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
 import { EstadoMaquinaService } from './estado-maquina.service';
 import { CreateEstadoMaquinaDto } from './dto/create-estado-maquina.dto';
 import { UpdateEstadoMaquinaDto } from './dto/update-estado-maquina.dto';
@@ -15,6 +25,18 @@ export class EstadoMaquinaController {
   @Get()
   findAll() {
     return this.service.findAll();
+  }
+
+  @Get('maquina/:id')
+  findByMaquina(
+    @Param('id') id: string,
+    @Query('inicio') inicio: string,
+    @Query('fin') fin: string,
+  ) {
+    if (!inicio || !fin) {
+      throw new BadRequestException('inicio y fin son requeridos');
+    }
+    return this.service.findByMaquina(id, inicio, fin);
   }
 
   @Get(':id')

--- a/src/estado-maquina/estado-maquina.service.ts
+++ b/src/estado-maquina/estado-maquina.service.ts
@@ -98,12 +98,22 @@ export class EstadoMaquinaService {
     return { deleted: true };
   }
 
-  findByMaquina(maquinaId: string) {
-    return this.repo.find({
-      where: { maquina: { id: maquinaId } },
-      relations: ['maquina'],
-      order: { inicio: 'DESC' },
-    });
+  findByMaquina(maquinaId: string, inicioStr: string, finStr: string) {
+    const inicio = DateTime.fromISO(inicioStr, {
+      zone: 'America/Bogota',
+    }).toJSDate();
+    const fin = DateTime.fromISO(finStr, {
+      zone: 'America/Bogota',
+    }).toJSDate();
+    return this.repo
+      .createQueryBuilder('estado')
+      .leftJoinAndSelect('estado.maquina', 'maquina')
+      .where('maquina.id = :maquinaId', { maquinaId })
+      .andWhere('estado.inicio <= :fin')
+      .andWhere('(estado.fin IS NULL OR estado.fin >= :inicio)')
+      .orderBy('estado.inicio', 'DESC')
+      .setParameters({ inicio, fin })
+      .getMany();
   }
 
   private async pausarPasoSesion(maquinaId: string, fecha: Date) {

--- a/src/estado-trabajador/estado-trabajador.controller.ts
+++ b/src/estado-trabajador/estado-trabajador.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, Post, Param, Body, Put, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Put,
+  Delete,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
 import { EstadoTrabajadorService } from './estado-trabajador.service';
 import { CreateEstadoTrabajadorDto } from './dto/create-estado-trabajador.dto';
 import { UpdateEstadoTrabajadorDto } from './dto/update-estado-trabajador.dto';
@@ -15,6 +25,18 @@ export class EstadoTrabajadorController {
   @Get()
   findAll() {
     return this.service.findAll();
+  }
+
+  @Get('trabajador/:id')
+  findByTrabajador(
+    @Param('id') id: string,
+    @Query('inicio') inicio: string,
+    @Query('fin') fin: string,
+  ) {
+    if (!inicio || !fin) {
+      throw new BadRequestException('inicio y fin son requeridos');
+    }
+    return this.service.findByTrabajador(id, inicio, fin);
   }
 
   @Get(':id')

--- a/src/estado-trabajador/estado-trabajador.service.ts
+++ b/src/estado-trabajador/estado-trabajador.service.ts
@@ -101,12 +101,22 @@ export class EstadoTrabajadorService {
     return { deleted: true };
   }
 
-  findByTrabajador(trabajadorId: string) {
-    return this.repo.find({
-      where: { trabajador: { id: trabajadorId } },
-      relations: ['trabajador'],
-      order: { inicio: 'DESC' },
-    });
+  findByTrabajador(trabajadorId: string, inicioStr: string, finStr: string) {
+    const inicio = DateTime.fromISO(inicioStr, {
+      zone: 'America/Bogota',
+    }).toJSDate();
+    const fin = DateTime.fromISO(finStr, {
+      zone: 'America/Bogota',
+    }).toJSDate();
+    return this.repo
+      .createQueryBuilder('estado')
+      .leftJoinAndSelect('estado.trabajador', 'trabajador')
+      .where('trabajador.id = :trabajadorId', { trabajadorId })
+      .andWhere('estado.inicio <= :fin')
+      .andWhere('(estado.fin IS NULL OR estado.fin >= :inicio)')
+      .orderBy('estado.inicio', 'DESC')
+      .setParameters({ inicio, fin })
+      .getMany();
   }
 
   private async pausarPasoSesion(trabajadorId: string, fecha: Date) {

--- a/src/registro-minuto/registro-minuto.controller.ts
+++ b/src/registro-minuto/registro-minuto.controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Post, Body, Get, Param } from '@nestjs/common'
-import { RegistroMinutoService } from './registro-minuto.service'
-import { AcumuladorDto } from './dto/acumulador.dto'
+import { Controller, Post, Body, Get, Param } from '@nestjs/common';
+import { RegistroMinutoService } from './registro-minuto.service';
+import { AcumuladorDto } from './dto/acumulador.dto';
 
 @Controller('registro-minuto')
 export class RegistroMinutoController {
@@ -8,21 +8,26 @@ export class RegistroMinutoController {
 
   @Post('acumular')
   async acumular(@Body() body: AcumuladorDto) {
-
-    const { maquina, paso, tipo, minutoInicio } = body
-    await this.service.acumular(maquina, paso, tipo, minutoInicio)
-    return { ok: true }
+    const { maquina, paso, tipo, minutoInicio } = body;
+    await this.service.acumular(maquina, paso, tipo, minutoInicio);
+    return { ok: true };
   }
 
   @Post('guardar')
   async guardar() {
-    await this.service.guardarYLimpiar()
-    return { ok: true }
+    await this.service.guardarYLimpiar();
+    return { ok: true };
   }
 
   @Get('sesion/:id')
   async obtenerPorSesion(@Param('id') id: string) {
-    const registros = await this.service.obtenerPorSesion(id)
-    return registros
+    const registros = await this.service.obtenerPorSesion(id);
+    return registros;
+  }
+
+  @Get('sesion/:id/ultimos')
+  async obtenerUltimos(@Param('id') id: string) {
+    const registros = await this.service.obtenerUltimosMinutos(id, 120);
+    return registros;
   }
 }


### PR DESCRIPTION
## Summary
- fill missing minute records when listing session data
- add endpoint to fetch last 120 minutes of a session
- add endpoints to list worker or machine states individually
- limit worker and machine state queries to specified date ranges in Colombia time

## Testing
- `npm test`
- `npx eslint src/estado-trabajador/estado-trabajador.controller.ts src/estado-trabajador/estado-trabajador.service.ts src/estado-maquina/estado-maquina.controller.ts src/estado-maquina/estado-maquina.service.ts` *(fails: @typescript-eslint/no-unused-vars, @typescript-eslint/no-unsafe-assignment, prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e1b61688325994970c16c0a863e