### PR TITLE
feat: add session and daily indicator entities

### DIFF
--- a/src/indicador-diario-dim/indicador-diario-dim.entity.ts
+++ b/src/indicador-diario-dim/indicador-diario-dim.entity.ts
@@ -1,0 +1,58 @@
+import { Entity, PrimaryColumn, Column } from 'typeorm';
+
+@Entity('indicador_diario_dim')
+export class IndicadorDiarioDim {
+  @PrimaryColumn({ type: 'date' })
+  fecha: string;
+
+  @PrimaryColumn({ nullable: true })
+  trabajadorId: string | null;
+
+  @PrimaryColumn({ nullable: true })
+  maquinaId: string | null;
+
+  @PrimaryColumn({ nullable: true })
+  areaId: string | null;
+
+  @Column('int')
+  produccionTotal: number;
+
+  @Column('int')
+  defectos: number;
+
+  @Column('float')
+  porcentajeDefectos: number;
+
+  @Column('float')
+  avgSpeed: number;
+
+  @Column('float')
+  avgSpeedSesion: number;
+
+  @Column('int')
+  nptMin: number;
+
+  @Column('int')
+  nptPorInactividad: number;
+
+  @Column('float')
+  porcentajeNPT: number;
+
+  @Column('int')
+  pausasCount: number;
+
+  @Column('int')
+  pausasMin: number;
+
+  @Column('float')
+  porcentajePausa: number;
+
+  @Column('int')
+  duracionTotalMin: number;
+
+  @Column('int')
+  sesionesCerradas: number;
+
+  @Column({ type: 'timestamp' })
+  updatedAt: Date;
+}

--- a/src/indicador-sesion-minuto/indicador-sesion-minuto.entity.ts
+++ b/src/indicador-sesion-minuto/indicador-sesion-minuto.entity.ts
@@ -1,0 +1,58 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+
+@Entity('indicador_sesion_minuto')
+@Index(['sesionTrabajo', 'minuto'])
+export class IndicadorSesionMinuto {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => SesionTrabajo, { nullable: false })
+  @JoinColumn({ name: 'sesionTrabajoId' })
+  sesionTrabajo: SesionTrabajo;
+
+  @Column({ type: 'timestamp' })
+  minuto: Date;
+
+  @Column('int')
+  produccionTotal: number;
+
+  @Column('int')
+  defectos: number;
+
+  @Column('float')
+  porcentajeDefectos: number;
+
+  @Column('float')
+  avgSpeed: number;
+
+  @Column('float')
+  avgSpeedSesion: number;
+
+  @Column('float')
+  velocidadActual: number;
+
+  @Column('int')
+  nptMin: number;
+
+  @Column('int')
+  nptPorInactividad: number;
+
+  @Column('float')
+  porcentajeNPT: number;
+
+  @Column('int')
+  pausasCount: number;
+
+  @Column('int')
+  pausasMin: number;
+
+  @Column('float')
+  porcentajePausa: number;
+
+  @Column('int')
+  duracionSesionMin: number;
+
+  @Column({ type: 'timestamp' })
+  actualizadoEn: Date;
+}

--- a/src/indicador-sesion/indicador-sesion.entity.ts
+++ b/src/indicador-sesion/indicador-sesion.entity.ts
@@ -1,0 +1,72 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+
+@Entity('indicador_sesion')
+export class IndicadorSesion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => SesionTrabajo, { nullable: false })
+  @JoinColumn({ name: 'sesionTrabajoId' })
+  sesionTrabajo: SesionTrabajo;
+
+  @Column()
+  areaIdSnapshot: string;
+
+  @Column()
+  trabajadorId: string;
+
+  @Column()
+  maquinaId: string;
+
+  @Column()
+  maquinaTipo: string;
+
+  @Column({ type: 'timestamp' })
+  fechaInicio: Date;
+
+  @Column({ type: 'timestamp' })
+  fechaFin: Date;
+
+  @Column('int')
+  produccionTotal: number;
+
+  @Column('int')
+  defectos: number;
+
+  @Column('float')
+  porcentajeDefectos: number;
+
+  @Column('float')
+  avgSpeed: number;
+
+  @Column('float')
+  avgSpeedSesion: number;
+
+  @Column('float')
+  velocidadMax10m: number;
+
+  @Column('int')
+  nptMin: number;
+
+  @Column('int')
+  nptPorInactividad: number;
+
+  @Column('float')
+  porcentajeNPT: number;
+
+  @Column('int')
+  pausasCount: number;
+
+  @Column('int')
+  pausasMin: number;
+
+  @Column('float')
+  porcentajePausa: number;
+
+  @Column('int')
+  duracionSesionMin: number;
+
+  @Column({ type: 'timestamp' })
+  creadoEn: Date;
+}


### PR DESCRIPTION
## Summary
- define `IndicadorSesionMinuto` to cache per-minute session metrics
- add `IndicadorSesion` for consolidated session snapshots
- introduce `IndicadorDiarioDim` for daily aggregated indicators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a51b6bdc188325aa53324292ec2589