### PR TITLE
feat: precalculate session indicators every minute

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { ProduccionDiariaModule } from './produccion-diaria/produccion-diaria.mo
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import * as fs from 'fs';
 import * as path from 'path';
+import { IndicadorSesionMinutoModule } from './indicador-sesion-minuto/indicador-sesion-minuto.module';
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import * as path from 'path';
     ProduccionDiariaModule,
 
     AuthModule,
+    IndicadorSesionMinutoModule,
   ],
   providers: [{ provide: APP_INTERCEPTOR, useClass: TimezoneInterceptor }],
 })

--- a/src/indicador-sesion-minuto/indicador-sesion-minuto.module.ts
+++ b/src/indicador-sesion-minuto/indicador-sesion-minuto.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IndicadorSesionMinuto } from './indicador-sesion-minuto.entity';
+import { IndicadorSesionMinutoService } from './indicador-sesion-minuto.service';
+import { PausaPasoSesion } from '../pausa-paso-sesion/pausa-paso-sesion.entity';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { SesionTrabajoModule } from '../sesion-trabajo/sesion-trabajo.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      IndicadorSesionMinuto,
+      PausaPasoSesion,
+      SesionTrabajo,
+    ]),
+    SesionTrabajoModule,
+  ],
+  providers: [IndicadorSesionMinutoService],
+  exports: [IndicadorSesionMinutoService],
+})
+export class IndicadorSesionMinutoModule {}

--- a/src/indicador-sesion-minuto/indicador-sesion-minuto.service.ts
+++ b/src/indicador-sesion-minuto/indicador-sesion-minuto.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, IsNull } from 'typeorm';
+import { DateTime } from 'luxon';
+import { IndicadorSesionMinuto } from './indicador-sesion-minuto.entity';
+import { PausaPasoSesion } from '../pausa-paso-sesion/pausa-paso-sesion.entity';
+import { SesionTrabajo } from '../sesion-trabajo/sesion-trabajo.entity';
+import { SesionTrabajoService } from '../sesion-trabajo/sesion-trabajo.service';
+
+@Injectable()
+export class IndicadorSesionMinutoService {
+  constructor(
+    @InjectRepository(IndicadorSesionMinuto)
+    private readonly repo: Repository<IndicadorSesionMinuto>,
+    @InjectRepository(PausaPasoSesion)
+    private readonly pausaRepo: Repository<PausaPasoSesion>,
+    @InjectRepository(SesionTrabajo)
+    private readonly sesionRepo: Repository<SesionTrabajo>,
+    private readonly sesionService: SesionTrabajoService,
+  ) {}
+
+  private async obtenerPausas(sesionId: string) {
+    const pausas = await this.pausaRepo
+      .createQueryBuilder('p')
+      .innerJoin('p.pasoSesion', 'ps')
+      .innerJoin('ps.sesionTrabajo', 's')
+      .where('s.id = :sesionId', { sesionId })
+      .getMany();
+    let minutos = 0;
+    for (const p of pausas) {
+      if (p.fin) {
+        const inicio = DateTime.fromJSDate(p.inicio, {
+          zone: 'America/Bogota',
+        });
+        const fin = DateTime.fromJSDate(p.fin, { zone: 'America/Bogota' });
+        minutos += Math.round(fin.diff(inicio, 'minutes').minutes);
+      }
+    }
+    return { count: pausas.length, minutos };
+  }
+
+  @Cron('* * * * *')
+  async generar() {
+    const sesiones = await this.sesionRepo.find({
+      where: { fechaFin: IsNull() },
+    });
+    const minuto = DateTime.now()
+      .setZone('America/Bogota')
+      .startOf('minute')
+      .toJSDate();
+    for (const sesion of sesiones) {
+      const indicadores =
+        await this.sesionService.calcularIndicadoresSesion(sesion);
+      const { count, minutos } = await this.obtenerPausas(sesion.id);
+      const totalProduccion =
+        indicadores.produccionTotal + indicadores.defectos;
+      const porcentajeDefectos =
+        totalProduccion > 0
+          ? (indicadores.defectos / totalProduccion) * 100
+          : 0;
+      const duracionSesionMin = Math.round(indicadores.totalMin);
+      const porcentajePausa =
+        duracionSesionMin > 0 ? (minutos / duracionSesionMin) * 100 : 0;
+      await this.repo.upsert(
+        {
+          sesionTrabajo: { id: sesion.id } as any,
+          minuto,
+          produccionTotal: indicadores.produccionTotal,
+          defectos: indicadores.defectos,
+          porcentajeDefectos,
+          avgSpeed: indicadores.avgSpeed,
+          avgSpeedSesion: indicadores.avgSpeedSesion,
+          velocidadActual: indicadores.velocidadActual,
+          nptMin: indicadores.nptMin,
+          nptPorInactividad: indicadores.nptPorInactividad,
+          porcentajeNPT: indicadores.porcentajeNPT,
+          pausasCount: count,
+          pausasMin: minutos,
+          porcentajePausa,
+          duracionSesionMin,
+          actualizadoEn: new Date(),
+        },
+        ['sesionTrabajo', 'minuto'],
+      );
+    }
+  }
+}

--- a/src/sesion-trabajo/sesion-trabajo.module.ts
+++ b/src/sesion-trabajo/sesion-trabajo.module.ts
@@ -10,6 +10,7 @@ import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity'
 import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 import { RegistroMinuto } from '../registro-minuto/registro-minuto.entity';
 import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
+import { IndicadorSesionMinuto } from '../indicador-sesion-minuto/indicador-sesion-minuto.entity';
 
 @Module({
   imports: [
@@ -20,11 +21,13 @@ import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.en
       SesionTrabajo,
       RegistroMinuto,
       SesionTrabajoPaso,
+      IndicadorSesionMinuto,
     ]),
     RegistroMinutoModule,
     EstadoSesionModule,
   ],
   providers: [SesionTrabajoService],
   controllers: [SesionTrabajoController],
+  exports: [SesionTrabajoService],
 })
 export class SesionTrabajoModule {}

--- a/src/sesion-trabajo/sesion-trabajo.service.spec.ts
+++ b/src/sesion-trabajo/sesion-trabajo.service.spec.ts
@@ -11,6 +11,7 @@ import { EstadoTrabajador } from '../estado-trabajador/estado-trabajador.entity'
 import { EstadoMaquina } from '../estado-maquina/estado-maquina.entity';
 import { ProduccionDiariaService } from '../produccion-diaria/produccion-diaria.service';
 import { SesionTrabajoPaso } from '../sesion-trabajo-paso/sesion-trabajo-paso.entity';
+import { IndicadorSesionMinuto } from '../indicador-sesion-minuto/indicador-sesion-minuto.entity';
 
 describe('SesionTrabajoService', () => {
   let service: SesionTrabajoService;
@@ -25,6 +26,7 @@ describe('SesionTrabajoService', () => {
         { provide: getRepositoryToken(EstadoTrabajador), useClass: Repository },
         { provide: getRepositoryToken(EstadoMaquina), useClass: Repository },
         { provide: getRepositoryToken(SesionTrabajoPaso), useClass: Repository },
+        { provide: getRepositoryToken(IndicadorSesionMinuto), useValue: { findOne: jest.fn() } },
         { provide: RegistroMinutoService, useValue: {} },
         { provide: EstadoSesionService, useValue: {} },
         { provide: ConfiguracionService, useValue: {} },


### PR DESCRIPTION
## Summary
- add worker to upsert per-minute session indicators
- wire indicator cache into session lookups
- expose session indicator module

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment of an `any` value, Unsafe member access errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a52451fc4c832582b6314b917fa73c