### PR TITLE
feat: store NPT minutes with decimal precision

### DIFF
--- a/src/indicador-sesion-minuto/indicador-sesion-minuto.entity.ts
+++ b/src/indicador-sesion-minuto/indicador-sesion-minuto.entity.ts
@@ -32,10 +32,10 @@ export class IndicadorSesionMinuto {
   @Column('float')
   velocidadActual: number;
 
-  @Column('int')
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
   nptMin: number;
 
-  @Column('int')
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
   nptPorInactividad: number;
 
   @Column('float')

--- a/src/indicador-sesion-minuto/indicador-sesion-minuto.service.ts
+++ b/src/indicador-sesion-minuto/indicador-sesion-minuto.service.ts
@@ -72,8 +72,10 @@ export class IndicadorSesionMinutoService {
           avgSpeed: indicadores.avgSpeed,
           avgSpeedSesion: indicadores.avgSpeedSesion,
           velocidadActual: indicadores.velocidadActual,
-          nptMin: indicadores.nptMin,
-          nptPorInactividad: indicadores.nptPorInactividad,
+          nptMin: Number(indicadores.nptMin.toFixed(2)),
+          nptPorInactividad: Number(
+            indicadores.nptPorInactividad.toFixed(2),
+          ),
           porcentajeNPT: indicadores.porcentajeNPT,
           pausasCount: count,
           pausasMin: minutos,


### PR DESCRIPTION
## Summary
- allow fractional NPT values in session-minute indicator
- round NPT metrics to two decimal places before storing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1168741f48325aadda2a478c798a3